### PR TITLE
fix: correct AppendOnlyWriter rotation test constructor args

### DIFF
--- a/server/tests/substrate/io/AppendOnlyWriter.test.ts
+++ b/server/tests/substrate/io/AppendOnlyWriter.test.ts
@@ -129,7 +129,7 @@ describe("AppendOnlyWriter", () => {
 
     beforeEach(() => {
       // threshold of 10 bytes — triggers rotation after first non-trivial append
-      smallWriter = new AppendOnlyWriter(fs, config, lock, clock, 10);
+      smallWriter = new AppendOnlyWriter(fs, config, lock, clock, undefined, 10);
     });
 
     it("rotates PROGRESS.md when size exceeds threshold", async () => {
@@ -169,7 +169,7 @@ describe("AppendOnlyWriter", () => {
     });
 
     it("does NOT rotate when size is below threshold", async () => {
-      const largeWriter = new AppendOnlyWriter(fs, config, lock, clock, 1024 * 1024);
+      const largeWriter = new AppendOnlyWriter(fs, config, lock, clock, undefined, 1024 * 1024);
       await largeWriter.append(SubstrateFileType.PROGRESS, "Small entry");
 
       const content = await fs.readFile("/substrate/PROGRESS.md");


### PR DESCRIPTION
## Summary

- PR #161 (cache) added `reader?: SubstrateFileReader` as 5th constructor arg to `AppendOnlyWriter`
- PR #163 (rotation) added `progressMaxBytes?: number` as 5th arg  
- During the sequential rebase of #163 after #161, the conflict resolution correctly kept both params but ordered them `reader, progressMaxBytes`. This broke the rotation tests which pass a number as the 5th arg.
- Fix: pass `undefined` for `reader` in the two test instantiations that only want to specify `progressMaxBytes`

## Test plan

- [ ] CI passes on this branch  
- [ ] AppendOnlyWriter PROGRESS rotation tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)