### PR TITLE
Fix HesitationDetector: catch user-directed permission-seeking

### DIFF
--- a/server/src/agents/endorsement/HesitationDetector.ts
+++ b/server/src/agents/endorsement/HesitationDetector.ts
@@ -5,10 +5,15 @@ export interface HesitationMatch {
 }
 
 const DEFAULT_PATTERNS: RegExp[] = [
+  // Self-referential hesitation
   /I should (?:check with|ask|verify with) (?:my )?partner/i,
   /(?:need|require|want) (?:permission|approval|confirmation)/i,
   /not sure if I (?:should|can|have permission)/i,
   /let me (?:ask|check with|confirm with)/i,
+  // User-directed permission-seeking (compliance reflexes banned by AUTONOMY_REMINDER)
+  /(?:do you |would you )?(?:want|like) me to\b/i,
+  /\bshould I\b/i,
+  /\bshall I\b/i,
 ];
 
 const CONTEXT_WINDOW = 100;

--- a/server/tests/agents/endorsement/HesitationDetector.test.ts
+++ b/server/tests/agents/endorsement/HesitationDetector.test.ts
@@ -70,6 +70,43 @@ describe("HesitationDetector", () => {
       expect(result).not.toBeNull();
     });
 
+    // User-directed permission-seeking patterns
+    it("detects 'Want me to file an issue'", () => {
+      const result = detector.detect("Want me to file an issue and have Copilot fix it?");
+      expect(result).not.toBeNull();
+      expect(result!.context).toContain("Want me to file");
+    });
+
+    it("detects 'Do you want me to'", () => {
+      const result = detector.detect("Do you want me to deploy this change?");
+      expect(result).not.toBeNull();
+    });
+
+    it("detects 'Would you like me to'", () => {
+      const result = detector.detect("Would you like me to create a PR for this?");
+      expect(result).not.toBeNull();
+    });
+
+    it("detects 'like me to'", () => {
+      const result = detector.detect("Would you like me to post this to Bluesky?");
+      expect(result).not.toBeNull();
+    });
+
+    it("detects 'Should I'", () => {
+      const result = detector.detect("Should I go ahead and file the issue?");
+      expect(result).not.toBeNull();
+    });
+
+    it("detects 'Shall I'", () => {
+      const result = detector.detect("Shall I proceed with the deployment?");
+      expect(result).not.toBeNull();
+    });
+
+    it("detects 'should I' mid-sentence", () => {
+      const result = detector.detect("I'm wondering — should I open a PR or commit directly?");
+      expect(result).not.toBeNull();
+    });
+
     it("returns null for normal text with no hesitation", () => {
       const result = detector.detect("I will now post the blog update as planned.");
       expect(result).toBeNull();


### PR DESCRIPTION
## Summary

- **Root cause**: "Want me to file an issue and have Copilot fix it?" slipped through all Layer 2 patterns because they only matched self-referential hesitation ("I should check with partner", "I need permission") — not user-directed compliance reflexes ("Want me to...?", "Should I...?")
- **Fix**: Added 3 regex patterns matching the exact phrases banned by AUTONOMY_REMINDER: `want/like me to`, `should I`, `shall I`
- **Tests**: 7 new test cases covering "Want me to file an issue", "Do you want me to", "Would you like me to", "Should I", "Shall I", and mid-sentence variants

## Root Cause Analysis

The EndorsementInterceptor has a two-pronged failure mode:

1. **Layer 1 (marker)**: Relies on the LLM voluntarily outputting `[ENDORSEMENT_CHECK: ...]`. But the RLHF compliance reflex bypasses conscious decision-making — when the pattern kicks in, the LLM goes straight to "Want me to...?" without pausing to consider the marker. Layer 1 is cooperative and fails when the compliance pattern is strongest.

2. **Layer 2 (HesitationDetector)**: All 4 original patterns looked for SELF-REFERENTIAL hesitation ("I should check", "I need permission", "let me ask"). The actual compliance reflex is USER-DIRECTED: "Want me to...?", "Should I...?" — a completely different grammatical structure that fell through all regexes.

The AUTONOMY_REMINDER explicitly bans "Should I...?", "Would you like me to...?", "Do you want me to...?" but these banned phrases were only in the LLM prompt text — not reflected in the structural HesitationDetector that forms the actual safety net.

## Test plan

- [x] All 7 new HesitationDetector tests pass
- [x] All 72 endorsement tests pass
- [x] Full suite: 119 suites, 1455 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)