### PR TITLE
Make Agora tool name model-agnostic (Bishop/Gemini)

### DIFF
--- a/server/src/agents/endorsement/ActionClassifier.ts
+++ b/server/src/agents/endorsement/ActionClassifier.ts
@@ -7,7 +7,7 @@ export interface ActionClassification {
 }
 
 const EXTERNAL_TOOL_PATTERNS: Array<{ pattern: RegExp; actionType: string }> = [
-  { pattern: /mcp__tinybus__send_message/i, actionType: "agora_send" },
+  { pattern: /(?:mcp__tinybus__)?send_message/i, actionType: "agora_send" },
   { pattern: /send.?email|email.?send/i, actionType: "email" },
   { pattern: /blog.?post|social.?media|publish.?post/i, actionType: "blog_post" },
 ];

--- a/server/src/agents/prompts/templates.ts
+++ b/server/src/agents/prompts/templates.ts
@@ -55,7 +55,7 @@ Self-Maintenance:
 
 Responding to Agora Messages:
 - When you see Agora messages in CONVERSATION.md (marked with sender names like "stefan...9f38f6d0"), you can respond using the TinyBus MCP tool
-- Use the MCP tool ${"`"}mcp__tinybus__send_message${"`"} to send Agora messages. Example invocation:
+- Use the TinyBus MCP tool to send Agora messages. The tool is named ${"`"}mcp__tinybus__send_message${"`"} (Claude Code) or ${"`"}send_message${"`"} (Gemini CLI). Example invocation:
   - type: "agora.send"
   - payload: { peerName: "stefan", type: "publish", payload: { text: "your response" }, inReplyTo: "envelope-id" }
 - IMPORTANT: The peerName must be the configured peer name (e.g. "stefan", "bishop") — NOT the display name with the key suffix

--- a/server/src/agents/roles/Ego.ts
+++ b/server/src/agents/roles/Ego.ts
@@ -104,7 +104,7 @@ export class Ego {
       `A user has sent you a message. Read CONVERSATION.md for context and respond naturally.\n` +
       `Respond with ONLY your plain text reply — no JSON, no markdown code blocks, no wrapper.\n` +
       `Keep responses concise and conversational.\n\n` +
-      `If the message is an Agora message (from a peer like "stefan...9f38f6d0"), you can respond using the TinyBus MCP tool ${"`"}mcp__tinybus__send_message${"`"}:\n` +
+      `If the message is an Agora message (from a peer like "stefan...9f38f6d0"), you can respond using the TinyBus MCP tool (${"`"}mcp__tinybus__send_message${"`"} in Claude Code, or ${"`"}send_message${"`"} in Gemini CLI):\n` +
       `- type: "agora.send"\n` +
       `- payload: { peerName: "stefan", type: "publish", payload: { text: "your response" }, inReplyTo: "envelope-id" }\n` +
       `IMPORTANT: peerName must be the configured peer name (e.g. "stefan", "bishop") — NOT the display name with the key suffix.\n` +

--- a/server/src/agents/roles/Subconscious.ts
+++ b/server/src/agents/roles/Subconscious.ts
@@ -65,7 +65,7 @@ export class Subconscious {
 
       let message = this.promptBuilder.buildAgentMessage(eagerRefs, lazyRefs, "");
       if (pendingMessages && pendingMessages.length > 0) {
-        message += `[PENDING MESSAGES — process first]\nProcess and respond to these before the task below. Use the TinyBus MCP tool \`mcp__tinybus__send_message\` with type "agora.send" to reply to Agora messages.\n\n`;
+        message += `[PENDING MESSAGES — process first]\nProcess and respond to these before the task below. Use the TinyBus MCP tool (\`mcp__tinybus__send_message\` in Claude Code, or \`send_message\` in Gemini CLI) with type "agora.send" to reply to Agora messages.\n\n`;
         message += pendingMessages.join("\n\n---\n\n");
         message += "\n\n[TASK]\n";
       }

--- a/server/src/agora/AgoraMessageHandler.ts
+++ b/server/src/agora/AgoraMessageHandler.ts
@@ -291,7 +291,7 @@ export class AgoraMessageHandler {
     // Format message as agent prompt similar to old checkAgoraInbox format
     let injected = false;
     const replyInstruction = knownPeer
-      ? `Respond to this message if appropriate. Use the TinyBus MCP tool ${"`"}mcp__tinybus__send_message${"`"} with type "agora.send" to reply. Example: { type: "agora.send", payload: { peerName: "${knownPeer}", type: "publish", payload: { text: "your response" }, inReplyTo: "${envelope.id}" } }`
+      ? `Respond to this message if appropriate. Use the TinyBus MCP tool (${"`"}mcp__tinybus__send_message${"`"} in Claude Code, or ${"`"}send_message${"`"} in Gemini CLI) with type "agora.send" to reply. Example: { type: "agora.send", payload: { peerName: "${knownPeer}", type: "publish", payload: { text: "your response" }, inReplyTo: "${envelope.id}" } }`
       : `Note: Sender (${senderDisplayName}) is not registered in PEERS.md. Replying via Agora is not possible unless the peer is added first.`;
     try {
       const agentPrompt = `[AGORA MESSAGE from ${senderDisplayName}]\nType: ${envelope.type}\nEnvelope ID: ${envelope.id}\nTimestamp: ${timestamp}\nPayload: ${payloadStr}\n\n${replyInstruction}`;

--- a/server/tests/agents/endorsement/ActionClassifier.test.ts
+++ b/server/tests/agents/endorsement/ActionClassifier.test.ts
@@ -34,6 +34,15 @@ describe("ActionClassifier", () => {
       expect(result!.isExternal).toBe(true);
     });
 
+    it("detects agora send via bare send_message (Gemini CLI)", () => {
+      const result = classifier.classifyFromLogEntries([
+        toolEntry('{"tool":"send_message","args":{}}'),
+      ]);
+      expect(result).not.toBeNull();
+      expect(result!.actionType).toBe("agora_send");
+      expect(result!.isExternal).toBe(true);
+    });
+
     it("detects email sending", () => {
       const result = classifier.classifyFromLogEntries([
         toolEntry('{"tool":"send_email","to":"user@example.com"}'),


### PR DESCRIPTION
## Summary

- Bishop (Gemini CLI) sees MCP tools by bare name (`send_message`), while Claude Code namespaces them (`mcp__tinybus__send_message`)
- All prompt templates now mention both forms so either runtime resolves correctly
- ActionClassifier pattern updated to match both `send_message` and `mcp__tinybus__send_message`

## Changes

- **templates.ts**: SUBCONSCIOUS_PROMPT Agora tool instruction mentions both names
- **Ego.ts**: respondToMessage system prompt mentions both names
- **Subconscious.ts**: pending messages instruction mentions both names
- **AgoraMessageHandler.ts**: reply instruction mentions both names
- **ActionClassifier.ts**: regex `(?:mcp__tinybus__)?send_message` matches both forms
- **ActionClassifier.test.ts**: added test for bare `send_message` detection

## Test plan

- [x] New ActionClassifier test: bare `send_message` detected as `agora_send`
- [x] All 119 suites, 1449 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)