### PR TITLE
Add --yolo to GeminiSessionLauncher for MCP tool execution

### DIFF
--- a/server/src/agents/gemini/GeminiSessionLauncher.ts
+++ b/server/src/agents/gemini/GeminiSessionLauncher.ts
@@ -18,6 +18,7 @@ const DEFAULT_MODEL = "gemini-2.5-pro";
  *   message       → -p "<message>"
  *   model         → -m <model>
  *   continueSession → -r (resume latest session)
+ *   --yolo        → auto-approve all tool calls (required for MCP in headless mode)
  */
 export class GeminiSessionLauncher implements ISessionLauncher {
   private readonly model: string;
@@ -43,7 +44,9 @@ export class GeminiSessionLauncher implements ISessionLauncher {
       ? `SYSTEM INSTRUCTIONS:\n${request.systemPrompt}\n\n---\n\n${request.message}`
       : request.message;
 
-    const args: string[] = ["-p", fullMessage, "-m", modelToUse];
+    // --yolo auto-approves MCP tool calls; without it, headless mode (-p)
+    // cannot execute tools and Gemini falls back to emitting tool_code blocks.
+    const args: string[] = ["-p", fullMessage, "-m", modelToUse, "--yolo"];
 
     if (options?.continueSession) {
       args.push("-r");

--- a/server/tests/agents/gemini/GeminiSessionLauncher.test.ts
+++ b/server/tests/agents/gemini/GeminiSessionLauncher.test.ts
@@ -22,7 +22,7 @@ describe("GeminiSessionLauncher", () => {
     launcher = new GeminiSessionLauncher(runner, clock);
   });
 
-  it("invokes gemini with -p and -m flags", async () => {
+  it("invokes gemini with -p, -m, and --yolo flags", async () => {
     runner.enqueue({ stdout: "response", stderr: "", exitCode: 0 });
 
     await launcher.launch(makeRequest({ message: "Do something" }));
@@ -32,6 +32,7 @@ describe("GeminiSessionLauncher", () => {
     expect(calls[0].command).toBe("gemini");
     expect(calls[0].args[0]).toBe("-p");
     expect(calls[0].args[2]).toBe("-m");
+    expect(calls[0].args).toContain("--yolo");
   });
 
   it("uses default model when none provided", async () => {


### PR DESCRIPTION
## Summary

- Bishop's Agora responses were failing silently — Gemini CLI generated `tool_code` blocks instead of executing MCP tools
- Root cause: headless mode (`-p`) requires `--yolo` flag to auto-approve tool calls
- Without it, Gemini falls back to emitting Python-style `default_api.send_message()` code that never reaches the MCP server

## Evidence from Bishop logs

```
[GeminiSessionLauncher] unwrapped preview: {
  "tool_code": "print(default_api.send_message(type='agora.send', ...))"
}
```

Bishop was *trying* to respond — the model correctly identified the tool and composed the call — but the CLI couldn't execute it without approval mode.

## Test plan

- [x] GeminiSessionLauncher test updated to verify `--yolo` flag present
- [x] All 13 GeminiSessionLauncher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)