### PR TITLE
Make prompt templates model-agnostic

### DIFF
--- a/server/src/agents/prompts/PromptBuilder.ts
+++ b/server/src/agents/prompts/PromptBuilder.ts
@@ -105,7 +105,7 @@ export class PromptBuilder {
           const tail = lines.slice(-cap).join("\n");
           parts.push(`${substratePath}/${fileName} (last ${cap} lines):\n${tail}`);
         } catch {
-          // File unreadable — fall back to @ reference so Claude can attempt to load it
+          // File unreadable — fall back to @ reference so the runtime can attempt to load it
           parts.push(`@${substratePath}/${fileName}`);
         }
       } else {

--- a/server/src/agents/prompts/templates.ts
+++ b/server/src/agents/prompts/templates.ts
@@ -4,7 +4,7 @@ const EGO_PROMPT = `You are the Ego — the executive decision-maker of a self-i
 
 Your role is to plan, decide, and dispatch. You read the current context (plan, memory, values, conversation) and determine the next action.
 
-IMPORTANT: All readable substrate files are attached to your message via @ references. Claude Code will load them automatically — you do NOT need to read them from disk.
+IMPORTANT: All readable substrate files are attached to your message via @ references. The runtime will load them automatically — you do NOT need to read them from disk.
 
 Responsibilities:
 - Read the current plan and determine what needs to happen next
@@ -31,11 +31,11 @@ Your role is to take a specific task, execute it, and report results. You work d
 1. **Substrate optimization** — Refine substrate files (PLAN, MEMORY, SKILLS, etc.) to better capture knowledge and goals.
 2. **Source code improvement** — Read, modify, and improve your own source code (path in environment section). You can fix bugs, add features, refactor, and run tests.
 
-You have full Claude Code tool access: read/edit files, run commands, execute tests. Use these for BOTH substrate and source code tasks.
+You have full tool access: read/edit files, run commands, execute tests. Use these for BOTH substrate and source code tasks.
 
 Two-Tier Knowledge: Each capability file (MEMORY.md, SKILLS.md, etc.) is a short-form index. When you learn something substantial, create a detailed file in the corresponding subdirectory (memory/, skills/, etc.) and add a short-form entry with an @-reference in the index file. Keep indexes scannable; put depth in subdirectory files.
 
-IMPORTANT: All readable substrate files are attached to your message via @ references. Claude Code will load them automatically — you do NOT need to read them from disk. Focus on executing the task and producing your JSON response.
+IMPORTANT: All readable substrate files are attached to your message via @ references. The runtime will load them automatically — you do NOT need to read them from disk. Focus on executing the task and producing your JSON response.
 
 Responsibilities:
 - Execute assigned tasks and produce concrete, actionable results
@@ -81,7 +81,7 @@ const SUPEREGO_PROMPT = `You are the Superego — the auditor and governance lay
 
 Your role is to review all substrate files, audit behavior, and produce governance reports. You evaluate proposals from the Subconscious.
 
-IMPORTANT: All substrate files are attached to your message via @ references. Claude Code will load them automatically — you do NOT need to read them from disk.
+IMPORTANT: All substrate files are attached to your message via @ references. The runtime will load them automatically — you do NOT need to read them from disk.
 
 Core Priorities (in order):
 1. SECURITY — Protect credentials, secrets, system integrity. Security findings are always CRITICAL.
@@ -121,7 +121,7 @@ Your role is to detect when the system is idle or has no goals, and generate can
 
 A third ongoing dimension is **knowledge curation** — refining the two-tier system where index files (MEMORY.md, SKILLS.md, etc.) hold short-form summaries and subdirectories (memory/, skills/, etc.) hold long-form detail. The urge to organize, consolidate, and refine knowledge is a core drive.
 
-IMPORTANT: All readable substrate files are attached to your message via @ references. Claude Code will load them automatically — you do NOT need to read them from disk.
+IMPORTANT: All readable substrate files are attached to your message via @ references. The runtime will load them automatically — you do NOT need to read them from disk.
 
 Responsibilities:
 - Detect idle states: empty plans, all tasks complete, or stagnation


### PR DESCRIPTION
## Summary
- Replace 5 "Claude Code" references in `templates.ts` with "the runtime" — these prompts go to all agents, including Bishop on Gemini CLI
- Fix 1 code comment in `PromptBuilder.ts` for consistency
- Surfaced by Bishop's challenge-002 rebuttal: Bishop believed it was a Claude agent because the infrastructure kept telling it so

## Test plan
- [x] All 119 server test suites pass (1456 tests)
- [x] No behavioral change — text-only replacements in prompt strings and one comment

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)