### PR TITLE
Fix startup scan false trigger on [UNPROCESSED]

### DIFF
--- a/server/src/loop/createLoopLayer.ts
+++ b/server/src/loop/createLoopLayer.ts
@@ -648,12 +648,15 @@ export async function createLoopLayer(
     orchestrator.setTickDependencies({ tickPromptBuilder, sdkSessionFactory });
   }
 
-  // Startup scan: check CONVERSATION.md for [UNPROCESSED] messages from before a restart.
+  // Startup scan: check CONVERSATION.md for **[UNPROCESSED]** messages from before a restart.
   // If found, queue a startup prompt so the agent will check for and handle them on the first cycle.
+  // IMPORTANT: Match the exact bold-markdown marker format "**[UNPROCESSED]**" used by
+  // AgoraMessageHandler and ConversationProvider — NOT the bare "[UNPROCESSED]" which
+  // can appear in historical log entries describing when markers were previously cleared.
   try {
     const conversationContent = await reader.read(SubstrateFileType.CONVERSATION);
-    if (conversationContent.rawMarkdown.includes("[UNPROCESSED]")) {
-      const startupPrompt = "[STARTUP SCAN] Unprocessed messages detected in CONVERSATION.md from before the last restart. Please read CONVERSATION.md and respond to any messages marked with [UNPROCESSED].";
+    if (conversationContent.rawMarkdown.includes("**[UNPROCESSED]**")) {
+      const startupPrompt = "[STARTUP SCAN] Unprocessed messages detected in CONVERSATION.md from before the last restart. Please read CONVERSATION.md and respond to any messages marked with **[UNPROCESSED]**.";
       orchestrator.queueStartupMessage(startupPrompt);
       logger.debug("createApplication: queued startup message for unprocessed messages in CONVERSATION.md");
     }


### PR DESCRIPTION
## Summary
- Startup scan matched bare `[UNPROCESSED]` which also appeared in historical EGO log entries (e.g. "All three [UNPROCESSED] messages handled")
- Caused 4+ consecutive false triggers on every restart, wasting a full agent cycle each time
- Fix: match exact bold-markdown format `**[UNPROCESSED]**` that AgoraMessageHandler and ConversationProvider use for actual markers

## Root cause
`createLoopLayer.ts` line 655: `conversationContent.rawMarkdown.includes("[UNPROCESSED]")` matched the bare string in an EGO log entry at CONVERSATION.md line 186 that described *clearing* those markers.

## Test plan
- [x] All 119 server test suites pass (1456 tests)
- [x] AgoraMessageHandler tests already verify markers use `**[UNPROCESSED]**` format
- [x] Verified CONVERSATION.md has zero `**[UNPROCESSED]**` occurrences (scan would correctly not trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)