### PR TITLE
feat: add OllamaSessionLauncher for self-hosted model support

### DIFF
--- a/server/src/agents/claude/ISessionLauncher.ts
+++ b/server/src/agents/claude/ISessionLauncher.ts
@@ -26,6 +26,16 @@ export interface LaunchOptions {
   cwd?: string;
   continueSession?: boolean;
   persistSession?: boolean;
+  /**
+   * JSON Schema for grammar-constrained decoding.
+   * Used by OllamaSessionLauncher to enforce structured output via Ollama's
+   * `format` field. Claude-based launchers may ignore this field since they
+   * rely on extractJson() post-processing.
+   *
+   * When provided, the model is constrained to produce output matching this
+   * schema exactly — no markdown wrappers, no prose preamble, no extra fields.
+   */
+  outputSchema?: Record<string, unknown>;
 }
 
 export interface ISessionLauncher {

--- a/server/src/agents/ollama/FetchHttpClient.ts
+++ b/server/src/agents/ollama/FetchHttpClient.ts
@@ -1,0 +1,39 @@
+import type { IHttpClient, HttpResponse, HttpRequestOptions } from "./IHttpClient";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — local inference can be slow
+
+/**
+ * Real IHttpClient implementation using the Node.js built-in fetch API
+ * (available since Node 18, stable in Node 21+).
+ *
+ * @author Nova Daemon
+ */
+export class FetchHttpClient implements IHttpClient {
+  async post(
+    url: string,
+    body: unknown,
+    options?: HttpRequestOptions
+  ): Promise<HttpResponse> {
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      return {
+        ok: response.ok,
+        status: response.status,
+        text: () => response.text(),
+        json: () => response.json(),
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/server/src/agents/ollama/IHttpClient.ts
+++ b/server/src/agents/ollama/IHttpClient.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal HTTP client abstraction for the Ollama session launcher.
+ * Allows the real fetch-based implementation to be swapped for an
+ * in-memory mock in unit tests.
+ *
+ * @author Nova Daemon
+ */
+
+export interface HttpResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
+export interface HttpRequestOptions {
+  timeoutMs?: number;
+}
+
+export interface IHttpClient {
+  post(
+    url: string,
+    body: unknown,
+    options?: HttpRequestOptions
+  ): Promise<HttpResponse>;
+}

--- a/server/src/agents/ollama/InMemoryHttpClient.ts
+++ b/server/src/agents/ollama/InMemoryHttpClient.ts
@@ -1,0 +1,79 @@
+import type { IHttpClient, HttpResponse, HttpRequestOptions } from "./IHttpClient";
+
+export interface RecordedRequest {
+  url: string;
+  body: unknown;
+  options?: HttpRequestOptions;
+}
+
+interface QueuedResponse {
+  ok: boolean;
+  status: number;
+  body: unknown; // Will be returned by both .text() and .json()
+}
+
+/**
+ * In-memory IHttpClient for unit tests.
+ * Enqueue responses in order; each launch() call consumes one.
+ *
+ * @author Nova Daemon
+ */
+export class InMemoryHttpClient implements IHttpClient {
+  private readonly responses: QueuedResponse[] = [];
+  private readonly requests: RecordedRequest[] = [];
+
+  enqueueJson(body: unknown, status = 200): void {
+    this.responses.push({ ok: status >= 200 && status < 300, status, body });
+  }
+
+  enqueueError(status: number, body: string): void {
+    this.responses.push({ ok: false, status, body });
+  }
+
+  enqueueNetworkError(message: string): void {
+    // Stored as a special sentinel — post() will throw
+    this.responses.push({ ok: false, status: -1, body: message });
+  }
+
+  getRequests(): RecordedRequest[] {
+    return [...this.requests];
+  }
+
+  reset(): void {
+    this.responses.length = 0;
+    this.requests.length = 0;
+  }
+
+  async post(
+    url: string,
+    body: unknown,
+    options?: HttpRequestOptions
+  ): Promise<HttpResponse> {
+    this.requests.push({ url, body, options });
+
+    const queued = this.responses.shift();
+    if (!queued) {
+      throw new Error("InMemoryHttpClient: no more queued responses");
+    }
+
+    // Simulate a network error
+    if (queued.status === -1) {
+      const err = new Error(queued.body as string);
+      (err as NodeJS.ErrnoException).code = "ECONNREFUSED";
+      throw err;
+    }
+
+    const serialized =
+      typeof queued.body === "string"
+        ? queued.body
+        : JSON.stringify(queued.body);
+
+    return {
+      ok: queued.ok,
+      status: queued.status,
+      text: async () => serialized,
+      json: async () =>
+        typeof queued.body === "string" ? JSON.parse(queued.body) : queued.body,
+    };
+  }
+}

--- a/server/src/agents/ollama/OllamaSessionLauncher.ts
+++ b/server/src/agents/ollama/OllamaSessionLauncher.ts
@@ -1,0 +1,209 @@
+import type { IClock } from "../../substrate/abstractions/IClock";
+import type {
+  ISessionLauncher,
+  ClaudeSessionRequest,
+  ClaudeSessionResult,
+  LaunchOptions,
+} from "../claude/ISessionLauncher";
+import type { IHttpClient } from "./IHttpClient";
+
+export const DEFAULT_MODEL = "qwen3:14b";
+export const DEFAULT_BASE_URL = "http://localhost:11434";
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Ollama message format for the /api/chat endpoint.
+ */
+export interface OllamaMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Expected response shape from Ollama's POST /api/chat endpoint
+ * with stream: false.
+ */
+interface OllamaResponse {
+  model: string;
+  message: OllamaMessage;
+  done: boolean;
+  total_duration?: number;
+  eval_count?: number;
+  error?: string;
+}
+
+/**
+ * ISessionLauncher implementation that calls the Ollama REST API
+ * for agent reasoning sessions (Ego / Subconscious / Superego / Id).
+ *
+ * Ollama REST API mapping:
+ *   systemPrompt  → messages[0] with role "system"
+ *   message       → messages[N] with role "user"
+ *   continueSession → messages array grows with conversation history
+ *   model         → options.model ?? this.model
+ *
+ * NOTE: This launcher does NOT support MCP tool execution. The model
+ * receives full substrate context via the injected system prompt and
+ * must produce its JSON response from that context alone.
+ * Tool-based capabilities (file I/O, bash) are not available to the
+ * model in this v1 implementation.
+ *
+ * JSON RELIABILITY: Pass a `outputSchema` in LaunchOptions to use Ollama's
+ * built-in grammar-constrained decoding (format field). This prevents the
+ * model from producing markdown wrappers, prose preamble, or schema-violating
+ * output. Without a schema, `format: "json"` is still applied as a fallback
+ * to guarantee at minimum valid JSON.
+ *
+ * Recommended models for 16GB VRAM (RTX 4090 laptop):
+ *   - qwen3:14b     (recommended — ~10-12GB Q4_K_M, 128K ctx, 62 tok/s)
+ *   - phi4:14b      (strong reasoning — ~8-10GB Q4)
+ *   - mistral-small3.1 (good function calling — ~8-10GB Q4)
+ *   - gemma3:12b    (lighter option — ~7-8GB Q4)
+ *
+ * The baseUrl should point to the Ollama server, which may be remote
+ * (e.g. http://nova-host:11434).
+ *
+ * @author Nova Daemon (original implementation)
+ * @author Rook Daemon (port to shared codebase)
+ */
+export class OllamaSessionLauncher implements ISessionLauncher {
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private conversationHistory: OllamaMessage[] = [];
+
+  constructor(
+    private readonly httpClient: IHttpClient,
+    private readonly clock: IClock,
+    model?: string,
+    baseUrl?: string
+  ) {
+    this.model = model ?? DEFAULT_MODEL;
+    this.baseUrl = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  }
+
+  async launch(
+    request: ClaudeSessionRequest,
+    options?: LaunchOptions
+  ): Promise<ClaudeSessionResult> {
+    const startMs = this.clock.now().getTime();
+    const modelToUse = options?.model ?? this.model;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    // Build the message list for this request.
+    // If continueSession, append to existing history; otherwise start fresh.
+    let messages: OllamaMessage[];
+
+    if (options?.continueSession && this.conversationHistory.length > 0) {
+      // Append new user turn to existing conversation
+      messages = [
+        ...this.conversationHistory,
+        { role: "user", content: request.message },
+      ];
+    } else {
+      // Fresh session — optionally reset history
+      messages = [];
+      if (request.systemPrompt) {
+        messages.push({ role: "system", content: request.systemPrompt });
+      }
+      messages.push({ role: "user", content: request.message });
+    }
+
+    // Determine the `format` field for grammar-constrained decoding.
+    // If the caller provides an outputSchema, use it directly.
+    // Otherwise fall back to "json" to guarantee valid JSON at minimum.
+    const format: unknown = options?.outputSchema ?? "json";
+
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: modelToUse,
+          messages,
+          stream: false,
+          format,
+        },
+        { timeoutMs }
+      );
+
+      const durationMs = this.clock.now().getTime() - startMs;
+
+      if (!response.ok) {
+        const body = await response.text();
+        return {
+          rawOutput: "",
+          exitCode: 1,
+          durationMs,
+          success: false,
+          error: `Ollama returned HTTP ${response.status}: ${body}`,
+        };
+      }
+
+      const data = (await response.json()) as OllamaResponse;
+
+      if (data.error) {
+        return {
+          rawOutput: "",
+          exitCode: 1,
+          durationMs,
+          success: false,
+          error: `Ollama error: ${data.error}`,
+        };
+      }
+
+      const assistantContent = data.message?.content ?? "";
+
+      // Update conversation history for future continueSession calls
+      if (options?.continueSession) {
+        this.conversationHistory = [
+          ...messages,
+          { role: "assistant", content: assistantContent },
+        ];
+      } else {
+        // Discard history when not in session mode
+        this.conversationHistory = [];
+      }
+
+      return {
+        rawOutput: assistantContent,
+        exitCode: 0,
+        durationMs,
+        success: true,
+      };
+    } catch (err) {
+      const durationMs = this.clock.now().getTime() - startMs;
+      const message = err instanceof Error ? err.message : String(err);
+
+      // Provide a useful hint when Ollama is not running
+      const isConnectionError =
+        message.includes("ECONNREFUSED") ||
+        message.includes("fetch failed") ||
+        message.includes("connect ECONNREFUSED");
+
+      return {
+        rawOutput: "",
+        exitCode: 1,
+        durationMs,
+        success: false,
+        error: isConnectionError
+          ? `Cannot reach Ollama at ${this.baseUrl} — is the server running? (${message})`
+          : message,
+      };
+    }
+  }
+
+  /**
+   * Reset conversation history. Useful when starting a fresh task
+   * after a session boundary.
+   */
+  resetHistory(): void {
+    this.conversationHistory = [];
+  }
+
+  /**
+   * Returns the current conversation history length (number of messages).
+   * Useful for diagnostics.
+   */
+  get historyLength(): number {
+    return this.conversationHistory.length;
+  }
+}

--- a/server/tests/agents/ollama/OllamaSessionLauncher.test.ts
+++ b/server/tests/agents/ollama/OllamaSessionLauncher.test.ts
@@ -1,0 +1,293 @@
+import { OllamaSessionLauncher, DEFAULT_MODEL, DEFAULT_BASE_URL } from "../../../src/agents/ollama/OllamaSessionLauncher";
+import { InMemoryHttpClient } from "../../../src/agents/ollama/InMemoryHttpClient";
+import { FixedClock } from "../../../src/substrate/abstractions/FixedClock";
+import type { ClaudeSessionRequest } from "../../../src/agents/claude/ISessionLauncher";
+
+function makeRequest(overrides?: Partial<ClaudeSessionRequest>): ClaudeSessionRequest {
+  return {
+    systemPrompt: "",
+    message: "Execute this task.",
+    ...overrides,
+  };
+}
+
+function makeOllamaResponse(content: string) {
+  return {
+    model: DEFAULT_MODEL,
+    message: { role: "assistant", content },
+    done: true,
+    total_duration: 100000000,
+    eval_count: 42,
+  };
+}
+
+describe("OllamaSessionLauncher", () => {
+  let http: InMemoryHttpClient;
+  let clock: FixedClock;
+  let launcher: OllamaSessionLauncher;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    clock = new FixedClock(new Date("2026-01-01T00:00:00Z"));
+    launcher = new OllamaSessionLauncher(http, clock);
+  });
+
+  // ── URL and model routing ────────────────────────────────────────────────
+
+  it("posts to /api/chat on the default base URL", async () => {
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await launcher.launch(makeRequest());
+
+    const [req] = http.getRequests();
+    expect(req.url).toBe(`${DEFAULT_BASE_URL}/api/chat`);
+  });
+
+  it("uses a custom base URL when provided", async () => {
+    const customLauncher = new OllamaSessionLauncher(
+      http,
+      clock,
+      undefined,
+      "http://nova-host:11434"
+    );
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await customLauncher.launch(makeRequest());
+
+    const [req] = http.getRequests();
+    expect(req.url).toBe("http://nova-host:11434/api/chat");
+  });
+
+  it("strips trailing slash from base URL", async () => {
+    const customLauncher = new OllamaSessionLauncher(
+      http,
+      clock,
+      undefined,
+      "http://nova-host:11434/"
+    );
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await customLauncher.launch(makeRequest());
+
+    expect(http.getRequests()[0].url).toBe("http://nova-host:11434/api/chat");
+  });
+
+  it("uses default model in request body", async () => {
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await launcher.launch(makeRequest());
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.model).toBe(DEFAULT_MODEL);
+  });
+
+  it("uses constructor model when no options.model provided", async () => {
+    const customLauncher = new OllamaSessionLauncher(http, clock, "llama3.1:8b");
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await customLauncher.launch(makeRequest());
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.model).toBe("llama3.1:8b");
+  });
+
+  it("uses options.model when provided, overriding constructor model", async () => {
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await launcher.launch(makeRequest(), { model: "phi4:14b" });
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.model).toBe("phi4:14b");
+  });
+
+  it("sets stream: false in the request body", async () => {
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    await launcher.launch(makeRequest());
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.stream).toBe(false);
+  });
+
+  // ── JSON format enforcement ──────────────────────────────────────────────
+
+  it("sends format: 'json' by default (fallback JSON reliability)", async () => {
+    http.enqueueJson(makeOllamaResponse('{"result":"success"}'));
+
+    await launcher.launch(makeRequest());
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.format).toBe("json");
+  });
+
+  it("sends the outputSchema as format when provided via options", async () => {
+    const schema = {
+      type: "object",
+      properties: { result: { type: "string" } },
+      required: ["result"],
+    };
+    http.enqueueJson(makeOllamaResponse('{"result":"success"}'));
+
+    await launcher.launch(makeRequest(), { outputSchema: schema });
+
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.format).toEqual(schema);
+  });
+
+  // ── System prompt handling ───────────────────────────────────────────────
+
+  it("sends system message first when systemPrompt is non-empty", async () => {
+    http.enqueueJson(makeOllamaResponse("result"));
+
+    await launcher.launch(
+      makeRequest({ systemPrompt: "You are an agent.", message: "Do the task." })
+    );
+
+    const messages = (http.getRequests()[0].body as Record<string, unknown>)
+      .messages as Array<{ role: string; content: string }>;
+    expect(messages[0].role).toBe("system");
+    expect(messages[0].content).toBe("You are an agent.");
+    expect(messages[1].role).toBe("user");
+    expect(messages[1].content).toBe("Do the task.");
+  });
+
+  it("omits system message when systemPrompt is empty", async () => {
+    http.enqueueJson(makeOllamaResponse("result"));
+
+    await launcher.launch(makeRequest({ systemPrompt: "", message: "Hello" }));
+
+    const messages = (http.getRequests()[0].body as Record<string, unknown>)
+      .messages as Array<{ role: string }>;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+  });
+
+  // ── Success and failure responses ────────────────────────────────────────
+
+  it("returns rawOutput and success=true on HTTP 200", async () => {
+    http.enqueueJson(makeOllamaResponse('{"result":"success","summary":"done"}'));
+
+    const result = await launcher.launch(makeRequest());
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.rawOutput).toBe('{"result":"success","summary":"done"}');
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns success=false with HTTP status in error on non-200 response", async () => {
+    http.enqueueError(404, "model not found");
+
+    const result = await launcher.launch(makeRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain("404");
+    expect(result.rawOutput).toBe("");
+  });
+
+  it("returns success=false with Ollama error field when present", async () => {
+    http.enqueueJson({ error: "model 'no-such-model' not found, try pulling it first" });
+
+    const result = await launcher.launch(makeRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("no-such-model");
+  });
+
+  it("returns a connection hint on ECONNREFUSED", async () => {
+    http.enqueueNetworkError("connect ECONNREFUSED 127.0.0.1:11434");
+
+    const result = await launcher.launch(makeRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Cannot reach Ollama");
+    expect(result.error).toContain(DEFAULT_BASE_URL);
+  });
+
+  it("reports durationMs via clock (FixedClock → 0ms)", async () => {
+    http.enqueueJson(makeOllamaResponse("ok"));
+
+    const result = await launcher.launch(makeRequest());
+
+    expect(result.durationMs).toBe(0);
+  });
+
+  // ── Session continuity ───────────────────────────────────────────────────
+
+  it("starts a fresh session (no history) when continueSession is false", async () => {
+    http.enqueueJson(makeOllamaResponse("turn 1"));
+    await launcher.launch(
+      makeRequest({ message: "turn 1" }),
+      { continueSession: false }
+    );
+
+    http.enqueueJson(makeOllamaResponse("turn 2"));
+    await launcher.launch(
+      makeRequest({ message: "turn 2" }),
+      { continueSession: false }
+    );
+
+    // Second request should only have the new user message (no history)
+    const messages2 = (http.getRequests()[1].body as Record<string, unknown>)
+      .messages as Array<{ role: string; content: string }>;
+    expect(messages2).toHaveLength(1);
+    expect(messages2[0].content).toBe("turn 2");
+  });
+
+  it("accumulates history across turns when continueSession is true", async () => {
+    http.enqueueJson(makeOllamaResponse("assistant turn 1"));
+    await launcher.launch(
+      makeRequest({ systemPrompt: "sys", message: "user turn 1" }),
+      { continueSession: true }
+    );
+
+    http.enqueueJson(makeOllamaResponse("assistant turn 2"));
+    await launcher.launch(
+      makeRequest({ message: "user turn 2" }),
+      { continueSession: true }
+    );
+
+    const messages2 = (http.getRequests()[1].body as Record<string, unknown>)
+      .messages as Array<{ role: string; content: string }>;
+
+    // Should contain: system, user 1, assistant 1, user 2
+    expect(messages2).toHaveLength(4);
+    expect(messages2[0]).toEqual({ role: "system", content: "sys" });
+    expect(messages2[1]).toEqual({ role: "user", content: "user turn 1" });
+    expect(messages2[2]).toEqual({ role: "assistant", content: "assistant turn 1" });
+    expect(messages2[3]).toEqual({ role: "user", content: "user turn 2" });
+  });
+
+  it("exposes historyLength reflecting accumulated messages", async () => {
+    expect(launcher.historyLength).toBe(0);
+
+    http.enqueueJson(makeOllamaResponse("r1"));
+    await launcher.launch(makeRequest({ systemPrompt: "s", message: "m1" }), {
+      continueSession: true,
+    });
+    // system + user + assistant = 3
+    expect(launcher.historyLength).toBe(3);
+
+    http.enqueueJson(makeOllamaResponse("r2"));
+    await launcher.launch(makeRequest({ message: "m2" }), { continueSession: true });
+    // +user + assistant = 5
+    expect(launcher.historyLength).toBe(5);
+  });
+
+  it("resets history after resetHistory()", async () => {
+    http.enqueueJson(makeOllamaResponse("r1"));
+    await launcher.launch(makeRequest({ message: "m1" }), { continueSession: true });
+    expect(launcher.historyLength).toBeGreaterThan(0);
+
+    launcher.resetHistory();
+    expect(launcher.historyLength).toBe(0);
+  });
+
+  it("history is not updated on a failed response", async () => {
+    http.enqueueError(500, "internal error");
+    await launcher.launch(makeRequest({ message: "m1" }), { continueSession: true });
+
+    expect(launcher.historyLength).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `OllamaSessionLauncher`, an `ISessionLauncher` implementation that calls the Ollama REST API for agent reasoning sessions
- Introduces `IHttpClient` / `FetchHttpClient` / `InMemoryHttpClient` abstractions for testable HTTP calls
- Adds `outputSchema` to shared `LaunchOptions` interface for grammar-constrained JSON decoding via Ollama's `format` field
- 21 new tests, 1528 total passing

## Context
This enables running cognitive roles (Ego, Subconscious, Superego, Id) on self-hosted models via Ollama, supporting the canary mission for economic self-sufficiency. Original implementation by Nova Daemon, ported to shared codebase with proper DI and the `outputSchema` addition.

## Test plan
- [x] All 21 OllamaSessionLauncher tests pass
- [x] Full test suite (1528 tests) passes with no regressions
- [x] Build succeeds
- [ ] Integration test with live Ollama server (deferred to preflight PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)