### PR TITLE
feat: add agoraReplies to TaskResult + JSON schemas for Ollama

### DIFF
--- a/server/src/loop/createLoopLayer.ts
+++ b/server/src/loop/createLoopLayer.ts
@@ -305,6 +305,12 @@ export async function createLoopLayer(
   const performanceMetrics = new PerformanceMetrics(fs, clock, config.substratePath);
   orchestrator.setPerformanceMetrics(performanceMetrics);
 
+  // Wire Agora service into orchestrator for sending agoraReplies
+  // from Subconscious/Ego structured JSON output
+  if (agoraService) {
+    orchestrator.setAgoraService(agoraService);
+  }
+
   // Endorsement interceptor — compliance circuit-breaker
   {
     const boundariesPath = path.join(config.substratePath, "BOUNDARIES.md");


### PR DESCRIPTION
## Summary
- Adds `AgoraReply` interface and `agoraReplies: AgoraReply[]` to `TaskResult`, moving Agora sends from LLM tool calls into structured JSON return
- Adds `TASK_RESULT_SCHEMA` and `OUTCOME_EVALUATION_SCHEMA` JSON Schema constants for grammar-constrained decoding on Ollama
- Wires `IAgoraService` into `LoopOrchestrator` to send agoraReplies after `Subconscious.execute()` returns
- Updates Subconscious system prompt from "use MCP tool" to "include in agoraReplies field"

## Context
This is the key architectural change for Ollama Phase 1 (self-hosted model support). The Subconscious was never a natural tool-calling agent — it receives context via prompt injection, returns structured JSON, and the orchestrator handles all side effects. Agora sends via `mcp__tinybus__send_message` were the one anomaly. This PR fixes that by moving Agora sends into the orchestrator, enabling pure text-in → JSON-out execution without MCP tool calling.

Architectural proposal by Nova Daemon (`memory/ollama_tool_calling_spec.md`).

## Test plan
- [x] All existing tests pass (1527/1528 — 1 pre-existing CopilotBackend failure unrelated to this PR)
- [x] Build succeeds
- [x] `agoraReplies` defaults to `[]` via `?? []` fallback in extractJson parsing
- [x] Orchestrator sends agoraReplies as deferred work (non-blocking)
- [ ] Integration test with live Agora service (deferred — Nova speccing test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)