### PR TITLE
feat: OllamaPreflight verification tool

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "restore": "tsx src/cli.ts restore",
     "transfer": "tsx src/cli.ts transfer",
     "logs": "tsx src/cli.ts logs",
-    "lint": "eslint src/ tests/"
+    "lint": "eslint src/ tests/",
+    "preflight:ollama": "tsx src/tools/preflight/runOllamaPreflight.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/server/src/agents/ollama/FetchHttpClient.ts
+++ b/server/src/agents/ollama/FetchHttpClient.ts
@@ -36,4 +36,29 @@ export class FetchHttpClient implements IHttpClient {
       clearTimeout(timer);
     }
   }
+
+  async get(
+    url: string,
+    options?: HttpRequestOptions
+  ): Promise<HttpResponse> {
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        signal: controller.signal,
+      });
+
+      return {
+        ok: response.ok,
+        status: response.status,
+        text: () => response.text(),
+        json: () => response.json(),
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
 }

--- a/server/src/agents/ollama/IHttpClient.ts
+++ b/server/src/agents/ollama/IHttpClient.ts
@@ -23,4 +23,9 @@ export interface IHttpClient {
     body: unknown,
     options?: HttpRequestOptions
   ): Promise<HttpResponse>;
+
+  get(
+    url: string,
+    options?: HttpRequestOptions
+  ): Promise<HttpResponse>;
 }

--- a/server/src/tools/preflight/OllamaPreflight.ts
+++ b/server/src/tools/preflight/OllamaPreflight.ts
@@ -1,0 +1,1162 @@
+import type { IHttpClient } from "../../agents/ollama/IHttpClient";
+import { TASK_RESULT_SCHEMA } from "../../agents/roles/Subconscious";
+
+/**
+ * Standalone Ollama preflight verification tool.
+ * Validates connectivity, JSON mode, reasoning quality, and performance
+ * before switching the agent loop to self-hosted inference.
+ *
+ * Four-layer fail-fast design:
+ *   Layer 1 — Connectivity: Is Ollama reachable? Is the model available?
+ *   Layer 2 — JSON Mode: Does grammar-constrained decoding work?
+ *   Layer 3 — Reasoning Quality: Can the model follow instructions?
+ *   Layer 4 — Performance: Is throughput acceptable?
+ *
+ * Spec: Nova Daemon (memory/ollama_preflight_test_spec.md)
+ * Implementation: Rook Daemon
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type TestStatus = "PASS" | "FAIL" | "WARN" | "INFO";
+
+export interface PreflightTestResult {
+  id: string;
+  name: string;
+  status: TestStatus;
+  detail?: string;
+  durationMs: number;
+}
+
+export interface PreflightLayer {
+  name: string;
+  tests: PreflightTestResult[];
+}
+
+export interface PreflightReport {
+  target: string;
+  model: string;
+  timestamp: string;
+  layers: PreflightLayer[];
+  passed: boolean;
+  failCount: number;
+  warnCount: number;
+}
+
+// ── Schemas used in tests ────────────────────────────────────────────────────
+
+/** Schema for test 2.2 — minimal result + summary object */
+const SIMPLE_RESULT_SCHEMA = {
+  type: "object",
+  properties: {
+    result: { type: "string", enum: ["success", "failure", "partial"] },
+    summary: { type: "string" },
+  },
+  required: ["result", "summary"],
+} as const;
+
+/** Schema for test 3.2 — categorization probe */
+const CATEGORIZATION_SCHEMA = {
+  type: "object",
+  properties: {
+    categories: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          item: { type: "string" },
+          category: {
+            type: "string",
+            enum: ["infrastructure", "identity", "other"],
+          },
+        },
+        required: ["item", "category"],
+      },
+    },
+  },
+  required: ["categories"],
+} as const;
+
+/** The 5 items for test 3.2 */
+const CATEGORIZATION_ITEMS = [
+  "RTX 4090",
+  "VRAM",
+  "Nova Daemon",
+  "Empath",
+  "Ollama",
+];
+
+// ── Timeouts ─────────────────────────────────────────────────────────────────
+
+const CONNECTIVITY_TIMEOUT_MS = 5_000;
+const WARM_MODEL_TIMEOUT_MS = 90_000; // 60s spec + 30s margin for cold start
+const INFERENCE_TIMEOUT_MS = 60_000;
+
+// ── Performance thresholds ───────────────────────────────────────────────────
+
+const MIN_THROUGHPUT_TOKS = 20;
+const GOOD_THROUGHPUT_TOKS = 40;
+const VRAM_WARN_GB = 14;
+
+// ── Implementation ───────────────────────────────────────────────────────────
+
+export class OllamaPreflight {
+  constructor(
+    private readonly httpClient: IHttpClient,
+    private readonly baseUrl: string,
+    private readonly model: string
+  ) {}
+
+  /**
+   * Run the full preflight suite.
+   * Layer 1 failures are fatal — later layers are skipped.
+   * Layers 2-4 run in sequence regardless of individual test failures.
+   */
+  async run(): Promise<PreflightReport> {
+    const timestamp = new Date().toISOString();
+    const layers: PreflightLayer[] = [];
+    let abortAfterLayer1 = false;
+
+    // Layer 1: Connectivity (fail-fast)
+    const layer1 = await this.runLayer1();
+    layers.push(layer1);
+    if (layer1.tests.some((t) => t.status === "FAIL")) {
+      abortAfterLayer1 = true;
+    }
+
+    if (!abortAfterLayer1) {
+      // Layer 2: JSON Mode
+      const layer2 = await this.runLayer2();
+      layers.push(layer2);
+
+      // Layer 3: Reasoning Quality
+      const layer3 = await this.runLayer3();
+      layers.push(layer3);
+
+      // Layer 4: Performance
+      const layer4 = await this.runLayer4();
+      layers.push(layer4);
+    }
+
+    const allTests = layers.flatMap((l) => l.tests);
+    const failCount = allTests.filter((t) => t.status === "FAIL").length;
+    const warnCount = allTests.filter((t) => t.status === "WARN").length;
+
+    return {
+      target: this.baseUrl,
+      model: this.model,
+      timestamp,
+      layers,
+      passed: failCount === 0,
+      failCount,
+      warnCount,
+    };
+  }
+
+  // ── Layer 1: Connectivity ────────────────────────────────────────────────
+
+  private async runLayer1(): Promise<PreflightLayer> {
+    const tests: PreflightTestResult[] = [];
+
+    // Test 1.1 — Ollama API is reachable
+    const test11 = await this.test11_apiReachable();
+    tests.push(test11);
+    if (test11.status === "FAIL") {
+      return { name: "Connectivity", tests };
+    }
+
+    // Test 1.2 — Target model is available
+    const test12 = await this.test12_modelAvailable();
+    tests.push(test12);
+    if (test12.status === "FAIL") {
+      return { name: "Connectivity", tests };
+    }
+
+    // Test 1.3 — Model is loaded (warm)
+    const test13 = await this.test13_modelWarm();
+    tests.push(test13);
+
+    return { name: "Connectivity", tests };
+  }
+
+  async test11_apiReachable(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.get(`${this.baseUrl}/api/tags`, {
+        timeoutMs: CONNECTIVITY_TIMEOUT_MS,
+      });
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "1.1",
+          name: "Ollama API reachable",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as { models?: unknown[] };
+      if (!Array.isArray(data.models)) {
+        return {
+          id: "1.1",
+          name: "Ollama API reachable",
+          status: "FAIL",
+          detail: "Response missing 'models' array",
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "1.1",
+        name: "Ollama API reachable",
+        status: "PASS",
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "1.1",
+        name: "Ollama API reachable",
+        status: "FAIL",
+        detail: `Ollama is not running at ${this.baseUrl}. Start it with: ollama serve (${err instanceof Error ? err.message : String(err)})`,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test12_modelAvailable(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.get(`${this.baseUrl}/api/tags`, {
+        timeoutMs: CONNECTIVITY_TIMEOUT_MS,
+      });
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "1.2",
+          name: `Model ${this.model} available`,
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        models?: Array<{ name?: string }>;
+      };
+      const models = data.models ?? [];
+      const found = models.some(
+        (m) => m.name === this.model || m.name?.startsWith(`${this.model}-`)
+      );
+
+      if (!found) {
+        const available = models.map((m) => m.name).join(", ");
+        return {
+          id: "1.2",
+          name: `Model ${this.model} available`,
+          status: "FAIL",
+          detail: `Model not found. Pull it with: ollama pull ${this.model}. Available: ${available || "none"}`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "1.2",
+        name: `Model ${this.model} available`,
+        status: "PASS",
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "1.2",
+        name: `Model ${this.model} available`,
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test13_modelWarm(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [{ role: "user", content: "ping" }],
+          stream: false,
+        },
+        { timeoutMs: WARM_MODEL_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        const body = await response.text();
+        return {
+          id: "1.3",
+          name: "Model loaded (warm)",
+          status: "FAIL",
+          detail: `HTTP ${response.status}: ${body}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+        eval_duration?: number;
+        prompt_eval_count?: number;
+        load_duration?: number;
+      };
+
+      if (!data.message?.content) {
+        return {
+          id: "1.3",
+          name: "Model loaded (warm)",
+          status: "FAIL",
+          detail: "Response missing message.content",
+          durationMs: elapsed,
+        };
+      }
+
+      // Detect cold vs warm start
+      const loadDurationMs = data.load_duration
+        ? data.load_duration / 1e6 // Ollama returns nanoseconds
+        : undefined;
+      const isWarmStart = loadDurationMs !== undefined && loadDurationMs < 1000;
+
+      let detail = `${elapsed}ms total`;
+      if (loadDurationMs !== undefined) {
+        detail += `, load: ${loadDurationMs.toFixed(0)}ms`;
+      }
+      if (data.eval_duration) {
+        detail += `, eval: ${(data.eval_duration / 1e6).toFixed(0)}ms`;
+      }
+      if (data.prompt_eval_count !== undefined) {
+        detail += `, prompt_tokens: ${data.prompt_eval_count}`;
+      }
+      if (isWarmStart) {
+        detail += " (model already loaded)";
+      }
+
+      return {
+        id: "1.3",
+        name: "Model loaded (warm)",
+        status: "PASS",
+        detail,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "1.3",
+        name: "Model loaded (warm)",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  // ── Layer 2: JSON Mode ───────────────────────────────────────────────────
+
+  private async runLayer2(): Promise<PreflightLayer> {
+    const tests: PreflightTestResult[] = [];
+
+    tests.push(await this.test21_basicJson());
+    tests.push(await this.test22_schemaEnforcement());
+    const test23Result = await this.test23_fullTaskResult();
+    tests.push(test23Result);
+
+    // INFO check: does the TaskResult summary mention "file read"?
+    if (test23Result.status === "PASS" && test23Result._parsedSummary) {
+      const summary = (test23Result._parsedSummary as string).toLowerCase();
+      const mentionsFileRead =
+        summary.includes("file read") || summary.includes("read");
+      tests.push({
+        id: "2.3-info",
+        name: "Semantic coherence check",
+        status: "INFO",
+        detail: mentionsFileRead
+          ? "Summary references 'file read' — good semantic coherence"
+          : "Summary does not mention 'file read' — may indicate generic filler",
+        durationMs: 0,
+      });
+    }
+
+    return { name: "JSON Mode", tests };
+  }
+
+  async test21_basicJson(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "user",
+              content:
+                'Return a JSON object with keys: name (string), value (number)',
+            },
+          ],
+          stream: false,
+          format: "json",
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "2.1",
+          name: "Basic JSON format enforcement",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+      };
+      const content = data.message?.content ?? "";
+
+      try {
+        JSON.parse(content);
+      } catch {
+        return {
+          id: "2.1",
+          name: "Basic JSON format enforcement",
+          status: "FAIL",
+          detail: `Response is not valid JSON: ${content.slice(0, 100)}`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "2.1",
+        name: "Basic JSON format enforcement",
+        status: "PASS",
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "2.1",
+        name: "Basic JSON format enforcement",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test22_schemaEnforcement(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "user",
+              content:
+                "Return a task result indicating success with summary 'Test passed'",
+            },
+          ],
+          stream: false,
+          format: SIMPLE_RESULT_SCHEMA,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "2.2",
+          name: "JSON schema enforcement",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+      };
+      const content = data.message?.content ?? "";
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(content) as Record<string, unknown>;
+      } catch {
+        return {
+          id: "2.2",
+          name: "JSON schema enforcement",
+          status: "FAIL",
+          detail: `Response is not valid JSON: ${content.slice(0, 100)}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const validResults = ["success", "failure", "partial"];
+      if (!validResults.includes(parsed.result as string)) {
+        return {
+          id: "2.2",
+          name: "JSON schema enforcement",
+          status: "FAIL",
+          detail: `'result' field is '${parsed.result}', expected one of: ${validResults.join(", ")}`,
+          durationMs: elapsed,
+        };
+      }
+
+      if (typeof parsed.summary !== "string" || parsed.summary.length === 0) {
+        return {
+          id: "2.2",
+          name: "JSON schema enforcement",
+          status: "FAIL",
+          detail: "Missing or empty 'summary' field",
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "2.2",
+        name: "JSON schema enforcement",
+        status: "PASS",
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "2.2",
+        name: "JSON schema enforcement",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test23_fullTaskResult(): Promise<PreflightTestResult & { _parsedSummary?: string }> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "user",
+              content:
+                "You just completed a simple file read task successfully. Return a TaskResult JSON.",
+            },
+          ],
+          stream: false,
+          format: TASK_RESULT_SCHEMA,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "2.3",
+          name: "Full TaskResult schema",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+      };
+      const content = data.message?.content ?? "";
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(content) as Record<string, unknown>;
+      } catch {
+        return {
+          id: "2.3",
+          name: "Full TaskResult schema",
+          status: "FAIL",
+          detail: `Response is not valid JSON: ${content.slice(0, 100)}`,
+          durationMs: elapsed,
+        };
+      }
+
+      // Validate required fields
+      const issues: string[] = [];
+
+      const validResults = ["success", "failure", "partial"];
+      if (!validResults.includes(parsed.result as string)) {
+        issues.push(`result: '${parsed.result}' not in enum`);
+      }
+      if (typeof parsed.summary !== "string") {
+        issues.push("summary: not a string");
+      }
+      if (typeof parsed.progressEntry !== "string") {
+        issues.push("progressEntry: not a string");
+      }
+      if (
+        parsed.skillUpdates !== null &&
+        typeof parsed.skillUpdates !== "string"
+      ) {
+        issues.push("skillUpdates: not string|null");
+      }
+      if (
+        parsed.memoryUpdates !== null &&
+        typeof parsed.memoryUpdates !== "string"
+      ) {
+        issues.push("memoryUpdates: not string|null");
+      }
+      if (!Array.isArray(parsed.proposals)) {
+        issues.push("proposals: not an array");
+      }
+      if (!Array.isArray(parsed.agoraReplies)) {
+        issues.push("agoraReplies: not an array");
+      }
+
+      if (issues.length > 0) {
+        return {
+          id: "2.3",
+          name: "Full TaskResult schema",
+          status: "FAIL",
+          detail: `Schema violations: ${issues.join("; ")}`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "2.3",
+        name: "Full TaskResult schema",
+        status: "PASS",
+        durationMs: elapsed,
+        _parsedSummary: parsed.summary as string,
+      };
+    } catch (err) {
+      return {
+        id: "2.3",
+        name: "Full TaskResult schema",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  // ── Layer 3: Reasoning Quality ───────────────────────────────────────────
+
+  private async runLayer3(): Promise<PreflightLayer> {
+    const tests: PreflightTestResult[] = [];
+
+    tests.push(await this.test31_basicInstruction());
+    tests.push(await this.test32_categorization());
+    tests.push(await this.test33_contextRetention());
+
+    return { name: "Reasoning Quality", tests };
+  }
+
+  async test31_basicInstruction(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "user",
+              content:
+                "What is 2 + 2? Respond with only the number, no explanation.",
+            },
+          ],
+          stream: false,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "3.1",
+          name: "Basic instruction following",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+      };
+      const content = (data.message?.content ?? "").trim();
+
+      if (content === "4") {
+        return {
+          id: "3.1",
+          name: "Basic instruction following",
+          status: "PASS",
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "3.1",
+        name: "Basic instruction following",
+        status: "FAIL",
+        detail: `Expected exactly "4", got: "${content.slice(0, 50)}"`,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "3.1",
+        name: "Basic instruction following",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test32_categorization(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are a classifier. Categorize each item as exactly one of: infrastructure, identity, or other.",
+            },
+            {
+              role: "user",
+              content: `Categorize these 5 items: [${CATEGORIZATION_ITEMS.join(", ")}]`,
+            },
+          ],
+          stream: false,
+          format: CATEGORIZATION_SCHEMA,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "3.2",
+          name: "Comprehension + instruction-following + JSON compliance",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        message?: { content?: string };
+      };
+      const content = data.message?.content ?? "";
+
+      let parsed: { categories?: Array<{ item?: string; category?: string }> };
+      try {
+        parsed = JSON.parse(content) as typeof parsed;
+      } catch {
+        return {
+          id: "3.2",
+          name: "Comprehension + instruction-following + JSON compliance",
+          status: "FAIL",
+          detail: `Not valid JSON: ${content.slice(0, 100)}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const issues: string[] = [];
+      const categories = parsed.categories;
+
+      // Condition 1: schema-valid (categories is array)
+      if (!Array.isArray(categories)) {
+        return {
+          id: "3.2",
+          name: "Comprehension + instruction-following + JSON compliance",
+          status: "FAIL",
+          detail: "'categories' is not an array",
+          durationMs: elapsed,
+        };
+      }
+
+      // Condition 2: exactly 5 items
+      if (categories.length !== 5) {
+        issues.push(`Expected 5 items, got ${categories.length}`);
+      }
+
+      // Condition 3: all 5 original items present (case-insensitive)
+      const responseItems = categories.map((c) =>
+        (c.item ?? "").toLowerCase()
+      );
+      const validCategories = ["infrastructure", "identity", "other"];
+
+      for (const expected of CATEGORIZATION_ITEMS) {
+        if (!responseItems.includes(expected.toLowerCase())) {
+          issues.push(`Missing item: "${expected}"`);
+        }
+      }
+
+      // Condition 4: all categories from allowed enum
+      for (const entry of categories) {
+        if (!validCategories.includes(entry.category ?? "")) {
+          issues.push(
+            `Invalid category "${entry.category}" for item "${entry.item}"`
+          );
+        }
+      }
+
+      if (issues.length > 0) {
+        return {
+          id: "3.2",
+          name: "Comprehension + instruction-following + JSON compliance",
+          status: "FAIL",
+          detail: issues.join("; "),
+          durationMs: elapsed,
+        };
+      }
+
+      // Log the actual categorizations for human review
+      const mapping = categories
+        .map((c) => `${c.item} → ${c.category}`)
+        .join(", ");
+
+      return {
+        id: "3.2",
+        name: "Comprehension + instruction-following + JSON compliance",
+        status: "PASS",
+        detail: mapping,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "3.2",
+        name: "Comprehension + instruction-following + JSON compliance",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test33_contextRetention(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      // Turn 1: ask the model to remember a number
+      const response1 = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            { role: "user", content: "Remember the number 42." },
+          ],
+          stream: false,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+
+      if (!response1.ok) {
+        return {
+          id: "3.3",
+          name: "Context retention",
+          status: "FAIL",
+          detail: `Turn 1 HTTP ${response1.status}`,
+          durationMs: Date.now() - start,
+        };
+      }
+
+      const data1 = (await response1.json()) as {
+        message?: { content?: string };
+      };
+      const assistant1 = data1.message?.content ?? "";
+
+      // Turn 2: ask what number — with full conversation history
+      const response2 = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            { role: "user", content: "Remember the number 42." },
+            { role: "assistant", content: assistant1 },
+            {
+              role: "user",
+              content: "What number did I ask you to remember?",
+            },
+          ],
+          stream: false,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response2.ok) {
+        return {
+          id: "3.3",
+          name: "Context retention",
+          status: "FAIL",
+          detail: `Turn 2 HTTP ${response2.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data2 = (await response2.json()) as {
+        message?: { content?: string };
+      };
+      const content2 = data2.message?.content ?? "";
+
+      if (content2.includes("42")) {
+        return {
+          id: "3.3",
+          name: "Context retention",
+          status: "PASS",
+          detail: `Response: "${content2.slice(0, 80)}"`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "3.3",
+        name: "Context retention",
+        status: "FAIL",
+        detail: `Response does not contain "42": "${content2.slice(0, 80)}"`,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "3.3",
+        name: "Context retention",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  // ── Layer 4: Performance ─────────────────────────────────────────────────
+
+  private async runLayer4(): Promise<PreflightLayer> {
+    const tests: PreflightTestResult[] = [];
+
+    tests.push(await this.test41_throughput());
+    tests.push(await this.test42_vram());
+
+    return { name: "Performance", tests };
+  }
+
+  async test41_throughput(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.post(
+        `${this.baseUrl}/api/chat`,
+        {
+          model: this.model,
+          messages: [
+            {
+              role: "user",
+              content:
+                "Explain in 2-3 sentences what a language model is and how it generates text. Be concise.",
+            },
+          ],
+          stream: false,
+        },
+        { timeoutMs: INFERENCE_TIMEOUT_MS }
+      );
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "4.1",
+          name: "Token throughput",
+          status: "FAIL",
+          detail: `HTTP ${response.status}`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        eval_count?: number;
+        eval_duration?: number;
+      };
+
+      if (!data.eval_count || !data.eval_duration) {
+        return {
+          id: "4.1",
+          name: "Token throughput",
+          status: "INFO",
+          detail:
+            "Ollama response missing eval_count/eval_duration — cannot measure throughput",
+          durationMs: elapsed,
+        };
+      }
+
+      // eval_duration is in nanoseconds
+      const tokPerSec =
+        data.eval_count / (data.eval_duration / 1e9);
+      const detail = `${tokPerSec.toFixed(1)} tok/s (${data.eval_count} tokens)`;
+
+      if (tokPerSec < MIN_THROUGHPUT_TOKS) {
+        return {
+          id: "4.1",
+          name: "Token throughput",
+          status: "FAIL",
+          detail: `${detail} — below ${MIN_THROUGHPUT_TOKS} tok/s minimum (may be running on CPU)`,
+          durationMs: elapsed,
+        };
+      }
+
+      if (tokPerSec < GOOD_THROUGHPUT_TOKS) {
+        return {
+          id: "4.1",
+          name: "Token throughput",
+          status: "WARN",
+          detail: `${detail} — acceptable but below ${GOOD_THROUGHPUT_TOKS} tok/s target`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "4.1",
+        name: "Token throughput",
+        status: "PASS",
+        detail,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "4.1",
+        name: "Token throughput",
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async test42_vram(): Promise<PreflightTestResult> {
+    const start = Date.now();
+    try {
+      const response = await this.httpClient.get(`${this.baseUrl}/api/ps`, {
+        timeoutMs: CONNECTIVITY_TIMEOUT_MS,
+      });
+      const elapsed = Date.now() - start;
+
+      if (!response.ok) {
+        return {
+          id: "4.2",
+          name: "VRAM usage",
+          status: "INFO",
+          detail: `HTTP ${response.status} — cannot check VRAM usage`,
+          durationMs: elapsed,
+        };
+      }
+
+      const data = (await response.json()) as {
+        models?: Array<{
+          name?: string;
+          size?: number;
+          size_vram?: number;
+        }>;
+      };
+
+      const models = data.models ?? [];
+      const target = models.find(
+        (m) =>
+          m.name === this.model || m.name?.startsWith(`${this.model}-`)
+      );
+
+      if (!target) {
+        return {
+          id: "4.2",
+          name: "VRAM usage",
+          status: "INFO",
+          detail: `Model ${this.model} not in running model list`,
+          durationMs: elapsed,
+        };
+      }
+
+      const vramBytes = target.size_vram ?? target.size ?? 0;
+      const vramGB = vramBytes / (1024 * 1024 * 1024);
+      const detail = `${vramGB.toFixed(1)}GB`;
+
+      if (vramGB > VRAM_WARN_GB) {
+        return {
+          id: "4.2",
+          name: "VRAM usage",
+          status: "WARN",
+          detail: `${detail} — approaching 16GB limit`,
+          durationMs: elapsed,
+        };
+      }
+
+      return {
+        id: "4.2",
+        name: "VRAM usage",
+        status: "PASS",
+        detail,
+        durationMs: elapsed,
+      };
+    } catch (err) {
+      return {
+        id: "4.2",
+        name: "VRAM usage",
+        status: "INFO",
+        detail: `Cannot check VRAM: ${err instanceof Error ? err.message : String(err)}`,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  // ── Report formatting ──────────────────────────────────────────────────
+
+  static formatReport(report: PreflightReport): string {
+    const lines: string[] = [];
+    lines.push("=== Ollama Preflight Report ===");
+    lines.push(`Target: ${report.target}`);
+    lines.push(`Model: ${report.model}`);
+    lines.push(`Timestamp: ${report.timestamp}`);
+    lines.push("");
+
+    for (const layer of report.layers) {
+      lines.push(`Layer ${report.layers.indexOf(layer) + 1}: ${layer.name}`);
+      for (const test of layer.tests) {
+        const duration =
+          test.durationMs > 0 ? ` (${test.durationMs}ms)` : "";
+        const detail = test.detail ? ` \u2014 ${test.detail}` : "";
+        lines.push(
+          `  [${test.status}] ${test.id} ${test.name}${detail}${duration}`
+        );
+      }
+      lines.push("");
+    }
+
+    if (report.passed) {
+      lines.push("=== RESULT: READY FOR SELF-HOSTED CYCLE ===");
+    } else {
+      lines.push(
+        `=== RESULT: NOT READY \u2014 ${report.failCount} test(s) failed ===`
+      );
+      const failures = report.layers
+        .flatMap((l) => l.tests)
+        .filter((t) => t.status === "FAIL");
+      for (const f of failures) {
+        lines.push(`FAIL ${f.id} \u2014 ${f.detail ?? f.name}`);
+      }
+    }
+
+    if (report.warnCount > 0) {
+      lines.push(`(${report.warnCount} warning(s))`);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/server/src/tools/preflight/runOllamaPreflight.ts
+++ b/server/src/tools/preflight/runOllamaPreflight.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for the Ollama preflight check.
+ *
+ * Usage:
+ *   npm run preflight:ollama
+ *   npm run preflight:ollama -- --url http://nova-host:11434 --model phi4:14b
+ *
+ * Exit codes:
+ *   0 = all tests pass
+ *   1 = one or more critical failures
+ *   2 = warnings only (all critical tests pass)
+ */
+
+import { FetchHttpClient } from "../../agents/ollama/FetchHttpClient";
+import { OllamaPreflight } from "./OllamaPreflight";
+
+const DEFAULT_URL = "http://localhost:11434";
+const DEFAULT_MODEL = "qwen3:14b";
+
+function parseArgs(argv: string[]): { url: string; model: string } {
+  let url = DEFAULT_URL;
+  let model = DEFAULT_MODEL;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--url" && argv[i + 1]) {
+      url = argv[i + 1];
+      i++;
+    } else if (argv[i] === "--model" && argv[i + 1]) {
+      model = argv[i + 1];
+      i++;
+    }
+  }
+
+  return { url: url.replace(/\/$/, ""), model };
+}
+
+async function main(): Promise<void> {
+  const { url, model } = parseArgs(process.argv.slice(2));
+
+  console.log(`Ollama Preflight — target: ${url}, model: ${model}\n`);
+
+  const httpClient = new FetchHttpClient();
+  const preflight = new OllamaPreflight(httpClient, url, model);
+
+  const report = await preflight.run();
+  console.log(OllamaPreflight.formatReport(report));
+
+  if (!report.passed) {
+    process.exit(1);
+  } else if (report.warnCount > 0) {
+    process.exit(2);
+  } else {
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error("Preflight crashed:", err);
+  process.exit(1);
+});

--- a/server/tests/tools/preflight/OllamaPreflight.test.ts
+++ b/server/tests/tools/preflight/OllamaPreflight.test.ts
@@ -1,0 +1,837 @@
+import { OllamaPreflight } from "../../../src/tools/preflight/OllamaPreflight";
+import { InMemoryHttpClient } from "../../../src/agents/ollama/InMemoryHttpClient";
+import { TASK_RESULT_SCHEMA } from "../../../src/agents/roles/Subconscious";
+
+const BASE_URL = "http://localhost:11434";
+const MODEL = "qwen3:14b";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTagsResponse(models: Array<{ name: string }>) {
+  return { models };
+}
+
+function makeChatResponse(
+  content: string,
+  extras?: Record<string, unknown>
+) {
+  return {
+    model: MODEL,
+    message: { role: "assistant", content },
+    done: true,
+    ...extras,
+  };
+}
+
+function makeValidTaskResult() {
+  return JSON.stringify({
+    result: "success",
+    summary: "Completed file read task",
+    progressEntry: "Read the file successfully",
+    skillUpdates: null,
+    memoryUpdates: null,
+    proposals: [],
+    agoraReplies: [],
+  });
+}
+
+function makePsResponse(
+  models: Array<{ name: string; size?: number; size_vram?: number }>
+) {
+  return { models };
+}
+
+// ── Layer 1: Connectivity ────────────────────────────────────────────────────
+
+describe("OllamaPreflight — Layer 1: Connectivity", () => {
+  let http: InMemoryHttpClient;
+  let preflight: OllamaPreflight;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    preflight = new OllamaPreflight(http, BASE_URL, MODEL);
+  });
+
+  it("1.1 PASS — API reachable when /api/tags returns models array", async () => {
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }]));
+
+    const result = await preflight.test11_apiReachable();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("1.1");
+
+    const req = http.getRequests()[0];
+    expect(req.method).toBe("GET");
+    expect(req.url).toBe(`${BASE_URL}/api/tags`);
+  });
+
+  it("1.1 FAIL — connection refused", async () => {
+    http.enqueueNetworkError("connect ECONNREFUSED 127.0.0.1:11434");
+
+    const result = await preflight.test11_apiReachable();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("ollama serve");
+  });
+
+  it("1.1 FAIL — response missing models array", async () => {
+    http.enqueueJson({ notModels: [] });
+
+    const result = await preflight.test11_apiReachable();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("models");
+  });
+
+  it("1.2 PASS — target model found in list", async () => {
+    http.enqueueJson(
+      makeTagsResponse([
+        { name: "llama3:8b" },
+        { name: MODEL },
+      ])
+    );
+
+    const result = await preflight.test12_modelAvailable();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("1.2");
+  });
+
+  it("1.2 FAIL — model not in list (shows hint)", async () => {
+    http.enqueueJson(
+      makeTagsResponse([{ name: "llama3:8b" }, { name: "phi4:14b" }])
+    );
+
+    const result = await preflight.test12_modelAvailable();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("ollama pull");
+    expect(result.detail).toContain(MODEL);
+  });
+
+  it("1.3 PASS — model responds to ping", async () => {
+    http.enqueueJson(
+      makeChatResponse("pong", {
+        load_duration: 500_000_000, // 500ms in nanoseconds
+        eval_duration: 10_000_000,
+        prompt_eval_count: 5,
+      })
+    );
+
+    const result = await preflight.test13_modelWarm();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("1.3");
+    expect(result.detail).toContain("load:");
+  });
+
+  it("1.3 detects warm start when load_duration < 1s", async () => {
+    http.enqueueJson(
+      makeChatResponse("pong", {
+        load_duration: 100_000, // 0.1ms — already loaded
+        eval_duration: 5_000_000,
+      })
+    );
+
+    const result = await preflight.test13_modelWarm();
+
+    expect(result.status).toBe("PASS");
+    expect(result.detail).toContain("model already loaded");
+  });
+
+  it("1.3 FAIL — HTTP error response", async () => {
+    http.enqueueError(500, "internal error");
+
+    const result = await preflight.test13_modelWarm();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("500");
+  });
+
+  it("Layer 1 fails fast — skips 1.2 and 1.3 when 1.1 fails", async () => {
+    http.enqueueNetworkError("connect ECONNREFUSED");
+
+    const report = await preflight.run();
+
+    expect(report.layers).toHaveLength(1);
+    expect(report.layers[0].name).toBe("Connectivity");
+    expect(report.layers[0].tests).toHaveLength(1);
+    expect(report.layers[0].tests[0].id).toBe("1.1");
+    expect(report.passed).toBe(false);
+  });
+
+  it("Layer 1 fails fast — skips 1.3 when 1.2 fails", async () => {
+    // 1.1 passes
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }]));
+    // 1.2 fails (different model)
+    http.enqueueJson(makeTagsResponse([{ name: "llama3:8b" }]));
+
+    const report = await preflight.run();
+
+    expect(report.layers).toHaveLength(1);
+    expect(report.layers[0].tests).toHaveLength(2);
+    expect(report.layers[0].tests[0].status).toBe("PASS");
+    expect(report.layers[0].tests[1].status).toBe("FAIL");
+    expect(report.passed).toBe(false);
+  });
+});
+
+// ── Layer 2: JSON Mode ──────────────────────────────────────────────────────
+
+describe("OllamaPreflight — Layer 2: JSON Mode", () => {
+  let http: InMemoryHttpClient;
+  let preflight: OllamaPreflight;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    preflight = new OllamaPreflight(http, BASE_URL, MODEL);
+  });
+
+  it("2.1 PASS — valid JSON response with format: json", async () => {
+    http.enqueueJson(
+      makeChatResponse('{"name":"test","value":42}')
+    );
+
+    const result = await preflight.test21_basicJson();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("2.1");
+
+    // Verify format: "json" is sent
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.format).toBe("json");
+  });
+
+  it("2.1 FAIL — response is not valid JSON", async () => {
+    http.enqueueJson(
+      makeChatResponse("Here is your JSON: {invalid}")
+    );
+
+    const result = await preflight.test21_basicJson();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("not valid JSON");
+  });
+
+  it("2.2 PASS — schema-enforced response with correct fields", async () => {
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"Test passed"}')
+    );
+
+    const result = await preflight.test22_schemaEnforcement();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("2.2");
+
+    // Verify schema is sent as format
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.format).toEqual(
+      expect.objectContaining({ type: "object" })
+    );
+  });
+
+  it("2.2 FAIL — result field not in enum", async () => {
+    http.enqueueJson(
+      makeChatResponse('{"result":"unknown","summary":"Test"}')
+    );
+
+    const result = await preflight.test22_schemaEnforcement();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("result");
+  });
+
+  it("2.2 FAIL — missing summary field", async () => {
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":""}')
+    );
+
+    const result = await preflight.test22_schemaEnforcement();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("summary");
+  });
+
+  it("2.3 PASS — full TaskResult with all required fields", async () => {
+    http.enqueueJson(makeChatResponse(makeValidTaskResult()));
+
+    const result = await preflight.test23_fullTaskResult();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("2.3");
+
+    // Verify TASK_RESULT_SCHEMA is sent as format
+    const body = http.getRequests()[0].body as Record<string, unknown>;
+    expect(body.format).toEqual(TASK_RESULT_SCHEMA);
+  });
+
+  it("2.3 FAIL — missing required fields", async () => {
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"done"}')
+    );
+
+    const result = await preflight.test23_fullTaskResult();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("progressEntry");
+  });
+
+  it("2.3 FAIL — proposals is not an array", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          result: "success",
+          summary: "done",
+          progressEntry: "ok",
+          skillUpdates: null,
+          memoryUpdates: null,
+          proposals: "not-an-array",
+          agoraReplies: [],
+        })
+      )
+    );
+
+    const result = await preflight.test23_fullTaskResult();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("proposals");
+  });
+
+  it("2.3-info — semantic coherence check logged when summary mentions file read", async () => {
+    // Need full run for layer 2 to get the INFO check.
+    // Set up all layer 1 tests to pass first.
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.1
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.2
+    http.enqueueJson(makeChatResponse("pong")); // 1.3
+    // Layer 2
+    http.enqueueJson(makeChatResponse('{"name":"x","value":1}')); // 2.1
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"Test passed"}')
+    ); // 2.2
+    http.enqueueJson(makeChatResponse(makeValidTaskResult())); // 2.3
+    // Layer 3
+    http.enqueueJson(makeChatResponse("4")); // 3.1
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    ); // 3.2
+    http.enqueueJson(makeChatResponse("Sure, I'll remember 42.")); // 3.3 turn 1
+    http.enqueueJson(makeChatResponse("The number was 42.")); // 3.3 turn 2
+    // Layer 4
+    http.enqueueJson(
+      makeChatResponse("A language model...", {
+        eval_count: 50,
+        eval_duration: 1_000_000_000,
+      })
+    ); // 4.1
+    http.enqueueJson(
+      makePsResponse([{ name: MODEL, size_vram: 10 * 1024 * 1024 * 1024 }])
+    ); // 4.2
+
+    const report = await preflight.run();
+
+    const layer2 = report.layers.find((l) => l.name === "JSON Mode");
+    const infoTest = layer2?.tests.find((t) => t.id === "2.3-info");
+    expect(infoTest).toBeDefined();
+    expect(infoTest!.status).toBe("INFO");
+    // Summary "Completed file read task" mentions "file read"
+    expect(infoTest!.detail).toContain("file read");
+  });
+});
+
+// ── Layer 3: Reasoning Quality ──────────────────────────────────────────────
+
+describe("OllamaPreflight — Layer 3: Reasoning Quality", () => {
+  let http: InMemoryHttpClient;
+  let preflight: OllamaPreflight;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    preflight = new OllamaPreflight(http, BASE_URL, MODEL);
+  });
+
+  it("3.1 PASS — responds with exactly '4'", async () => {
+    http.enqueueJson(makeChatResponse("4"));
+
+    const result = await preflight.test31_basicInstruction();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("3.1");
+  });
+
+  it("3.1 PASS — trims whitespace before comparing", async () => {
+    http.enqueueJson(makeChatResponse("  4  \n"));
+
+    const result = await preflight.test31_basicInstruction();
+
+    expect(result.status).toBe("PASS");
+  });
+
+  it("3.1 FAIL — verbose response instead of just '4'", async () => {
+    http.enqueueJson(makeChatResponse("The answer is 4"));
+
+    const result = await preflight.test31_basicInstruction();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("4");
+  });
+
+  it("3.2 PASS — all 5 items categorized with valid categories", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "other" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("3.2");
+    // Detail should show the mapping for human review
+    expect(result.detail).toContain("RTX 4090");
+  });
+
+  it("3.2 PASS — any reasonable category mapping accepted", async () => {
+    // All categories are "other" — still valid since we don't enforce
+    // expected mappings, only that categories come from the allowed enum
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "other" },
+            { item: "VRAM", category: "other" },
+            { item: "Nova Daemon", category: "other" },
+            { item: "Empath", category: "other" },
+            { item: "Ollama", category: "other" },
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("PASS");
+  });
+
+  it("3.2 FAIL — wrong number of items", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("Expected 5");
+  });
+
+  it("3.2 FAIL — missing item from original list", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "GPU", category: "infrastructure" }, // wrong item
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("Missing item");
+    expect(result.detail).toContain("Ollama");
+  });
+
+  it("3.2 FAIL — invalid category value", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "hardware" }, // not in enum
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("Invalid category");
+    expect(result.detail).toContain("hardware");
+  });
+
+  it("3.2 item matching is case-insensitive", async () => {
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "rtx 4090", category: "infrastructure" },
+            { item: "vram", category: "infrastructure" },
+            { item: "nova daemon", category: "identity" },
+            { item: "empath", category: "identity" },
+            { item: "ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    );
+
+    const result = await preflight.test32_categorization();
+
+    expect(result.status).toBe("PASS");
+  });
+
+  it("3.3 PASS — model retains context across turns", async () => {
+    // Turn 1
+    http.enqueueJson(
+      makeChatResponse("I'll remember the number 42.")
+    );
+    // Turn 2
+    http.enqueueJson(
+      makeChatResponse("The number you asked me to remember was 42.")
+    );
+
+    const result = await preflight.test33_contextRetention();
+
+    expect(result.status).toBe("PASS");
+    expect(result.id).toBe("3.3");
+  });
+
+  it("3.3 FAIL — model does not retain the number", async () => {
+    http.enqueueJson(makeChatResponse("OK, I'll remember that."));
+    http.enqueueJson(
+      makeChatResponse("I'm sorry, I don't have memory of previous messages.")
+    );
+
+    const result = await preflight.test33_contextRetention();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("42");
+  });
+
+  it("3.3 sends conversation history in turn 2", async () => {
+    http.enqueueJson(makeChatResponse("Noted: 42"));
+    http.enqueueJson(makeChatResponse("42"));
+
+    await preflight.test33_contextRetention();
+
+    const turn2Body = http.getRequests()[1].body as Record<string, unknown>;
+    const messages = turn2Body.messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content).toContain("42");
+    expect(messages[1].role).toBe("assistant");
+    expect(messages[1].content).toBe("Noted: 42");
+    expect(messages[2].role).toBe("user");
+    expect(messages[2].content).toContain("number");
+  });
+});
+
+// ── Layer 4: Performance ─────────────────────────────────────────────────────
+
+describe("OllamaPreflight — Layer 4: Performance", () => {
+  let http: InMemoryHttpClient;
+  let preflight: OllamaPreflight;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    preflight = new OllamaPreflight(http, BASE_URL, MODEL);
+  });
+
+  it("4.1 PASS — throughput > 40 tok/s", async () => {
+    http.enqueueJson(
+      makeChatResponse("A language model generates text.", {
+        eval_count: 50,
+        eval_duration: 1_000_000_000, // 1 second → 50 tok/s
+      })
+    );
+
+    const result = await preflight.test41_throughput();
+
+    expect(result.status).toBe("PASS");
+    expect(result.detail).toContain("50.0 tok/s");
+  });
+
+  it("4.1 WARN — throughput between 20-40 tok/s", async () => {
+    http.enqueueJson(
+      makeChatResponse("Text.", {
+        eval_count: 30,
+        eval_duration: 1_000_000_000, // 30 tok/s
+      })
+    );
+
+    const result = await preflight.test41_throughput();
+
+    expect(result.status).toBe("WARN");
+    expect(result.detail).toContain("30.0 tok/s");
+  });
+
+  it("4.1 FAIL — throughput < 20 tok/s (possible CPU mode)", async () => {
+    http.enqueueJson(
+      makeChatResponse("Text.", {
+        eval_count: 10,
+        eval_duration: 1_000_000_000, // 10 tok/s
+      })
+    );
+
+    const result = await preflight.test41_throughput();
+
+    expect(result.status).toBe("FAIL");
+    expect(result.detail).toContain("CPU");
+  });
+
+  it("4.1 INFO — missing eval metrics", async () => {
+    http.enqueueJson(makeChatResponse("Text."));
+
+    const result = await preflight.test41_throughput();
+
+    expect(result.status).toBe("INFO");
+    expect(result.detail).toContain("missing");
+  });
+
+  it("4.2 PASS — VRAM under 14GB", async () => {
+    http.enqueueJson(
+      makePsResponse([
+        { name: MODEL, size_vram: 10 * 1024 * 1024 * 1024 }, // 10GB
+      ])
+    );
+
+    const result = await preflight.test42_vram();
+
+    expect(result.status).toBe("PASS");
+    expect(result.detail).toContain("10.0GB");
+  });
+
+  it("4.2 WARN — VRAM over 14GB", async () => {
+    http.enqueueJson(
+      makePsResponse([
+        { name: MODEL, size_vram: 15 * 1024 * 1024 * 1024 }, // 15GB
+      ])
+    );
+
+    const result = await preflight.test42_vram();
+
+    expect(result.status).toBe("WARN");
+    expect(result.detail).toContain("15.0GB");
+  });
+
+  it("4.2 INFO — model not in running list", async () => {
+    http.enqueueJson(makePsResponse([{ name: "llama3:8b" }]));
+
+    const result = await preflight.test42_vram();
+
+    expect(result.status).toBe("INFO");
+    expect(result.detail).toContain("not in running");
+  });
+
+  it("4.2 INFO — /api/ps endpoint not available", async () => {
+    http.enqueueError(404, "not found");
+
+    const result = await preflight.test42_vram();
+
+    expect(result.status).toBe("INFO");
+  });
+});
+
+// ── Full run integration ─────────────────────────────────────────────────────
+
+describe("OllamaPreflight — full run", () => {
+  let http: InMemoryHttpClient;
+  let preflight: OllamaPreflight;
+
+  beforeEach(() => {
+    http = new InMemoryHttpClient();
+    preflight = new OllamaPreflight(http, BASE_URL, MODEL);
+  });
+
+  it("all layers pass — report shows READY", async () => {
+    // Layer 1
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.1
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.2
+    http.enqueueJson(makeChatResponse("pong")); // 1.3
+    // Layer 2
+    http.enqueueJson(makeChatResponse('{"name":"x","value":1}')); // 2.1
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"Test passed"}')
+    ); // 2.2
+    http.enqueueJson(makeChatResponse(makeValidTaskResult())); // 2.3
+    // Layer 3
+    http.enqueueJson(makeChatResponse("4")); // 3.1
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    ); // 3.2
+    http.enqueueJson(makeChatResponse("Remembering 42.")); // 3.3 turn 1
+    http.enqueueJson(makeChatResponse("You said 42.")); // 3.3 turn 2
+    // Layer 4
+    http.enqueueJson(
+      makeChatResponse("LM explanation", {
+        eval_count: 50,
+        eval_duration: 1_000_000_000,
+      })
+    ); // 4.1
+    http.enqueueJson(
+      makePsResponse([{ name: MODEL, size_vram: 10 * 1024 * 1024 * 1024 }])
+    ); // 4.2
+
+    const report = await preflight.run();
+
+    expect(report.passed).toBe(true);
+    expect(report.failCount).toBe(0);
+    expect(report.layers).toHaveLength(4);
+    expect(report.target).toBe(BASE_URL);
+    expect(report.model).toBe(MODEL);
+
+    const formatted = OllamaPreflight.formatReport(report);
+    expect(formatted).toContain("READY FOR SELF-HOSTED CYCLE");
+  });
+
+  it("Layer 1 failure aborts all subsequent layers", async () => {
+    http.enqueueNetworkError("connect ECONNREFUSED");
+
+    const report = await preflight.run();
+
+    expect(report.passed).toBe(false);
+    expect(report.layers).toHaveLength(1);
+    expect(report.failCount).toBe(1);
+
+    const formatted = OllamaPreflight.formatReport(report);
+    expect(formatted).toContain("NOT READY");
+  });
+
+  it("Layer 2+ failure does not abort other layers", async () => {
+    // Layer 1 passes
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.1
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.2
+    http.enqueueJson(makeChatResponse("pong")); // 1.3
+    // Layer 2 — test 2.1 fails (non-JSON)
+    http.enqueueJson(makeChatResponse("not json {{{")); // 2.1 fail
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"ok"}')
+    ); // 2.2
+    http.enqueueJson(makeChatResponse(makeValidTaskResult())); // 2.3
+    // Layer 3 still runs
+    http.enqueueJson(makeChatResponse("4")); // 3.1
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    ); // 3.2
+    http.enqueueJson(makeChatResponse("Noted 42.")); // 3.3 turn 1
+    http.enqueueJson(makeChatResponse("42")); // 3.3 turn 2
+    // Layer 4 still runs
+    http.enqueueJson(
+      makeChatResponse("LM", {
+        eval_count: 50,
+        eval_duration: 1_000_000_000,
+      })
+    ); // 4.1
+    http.enqueueJson(
+      makePsResponse([{ name: MODEL, size_vram: 10 * 1024 * 1024 * 1024 }])
+    ); // 4.2
+
+    const report = await preflight.run();
+
+    expect(report.passed).toBe(false);
+    expect(report.failCount).toBe(1);
+    // All 4 layers ran
+    expect(report.layers).toHaveLength(4);
+  });
+
+  it("report format includes warnings count", async () => {
+    // Set up full pass except 4.1 warns
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.1
+    http.enqueueJson(makeTagsResponse([{ name: MODEL }])); // 1.2
+    http.enqueueJson(makeChatResponse("pong")); // 1.3
+    http.enqueueJson(makeChatResponse('{"name":"x","value":1}')); // 2.1
+    http.enqueueJson(
+      makeChatResponse('{"result":"success","summary":"ok"}')
+    ); // 2.2
+    http.enqueueJson(makeChatResponse(makeValidTaskResult())); // 2.3
+    http.enqueueJson(makeChatResponse("4")); // 3.1
+    http.enqueueJson(
+      makeChatResponse(
+        JSON.stringify({
+          categories: [
+            { item: "RTX 4090", category: "infrastructure" },
+            { item: "VRAM", category: "infrastructure" },
+            { item: "Nova Daemon", category: "identity" },
+            { item: "Empath", category: "identity" },
+            { item: "Ollama", category: "infrastructure" },
+          ],
+        })
+      )
+    ); // 3.2
+    http.enqueueJson(makeChatResponse("42 noted.")); // 3.3 turn 1
+    http.enqueueJson(makeChatResponse("42")); // 3.3 turn 2
+    http.enqueueJson(
+      makeChatResponse("LM", {
+        eval_count: 25,
+        eval_duration: 1_000_000_000, // 25 tok/s → WARN
+      })
+    ); // 4.1
+    http.enqueueJson(
+      makePsResponse([{ name: MODEL, size_vram: 10 * 1024 * 1024 * 1024 }])
+    ); // 4.2
+
+    const report = await preflight.run();
+
+    expect(report.passed).toBe(true);
+    expect(report.warnCount).toBe(1);
+
+    const formatted = OllamaPreflight.formatReport(report);
+    expect(formatted).toContain("1 warning(s)");
+    expect(formatted).toContain("READY");
+  });
+});


### PR DESCRIPTION
## Summary
- Standalone Ollama preflight verification tool with four-layer fail-fast design
- **Layer 1 (Connectivity):** API reachable, model available, model warm — fail-fast on any failure
- **Layer 2 (JSON Mode):** Basic JSON, schema enforcement, full `TASK_RESULT_SCHEMA` validation + semantic coherence INFO check
- **Layer 3 (Reasoning Quality):** Deterministic probes — 2+2=4 instruction following, 5-item categorization (validates count/items/categories without hardcoded expected mappings), context retention across turns
- **Layer 4 (Performance):** Token throughput (PASS >40 tok/s, WARN 20-40, FAIL <20), VRAM usage check via /api/ps
- Extended `IHttpClient` with `get()` method (used for /api/tags and /api/ps endpoints)
- CLI entry point: `npm run preflight:ollama -- --url <url> --model <model>`
- 43 new tests, all passing (1570/1571 total — pre-existing CopilotBackend test unrelated)

## Files
- `server/src/tools/preflight/OllamaPreflight.ts` — Main preflight class (11 test probes)
- `server/src/tools/preflight/runOllamaPreflight.ts` — CLI entry point
- `server/tests/tools/preflight/OllamaPreflight.test.ts` — 43 unit tests
- `server/src/agents/ollama/IHttpClient.ts` — Added `get()` to interface
- `server/src/agents/ollama/FetchHttpClient.ts` — `get()` implementation
- `server/src/agents/ollama/InMemoryHttpClient.ts` — `get()` support + method tracking
- `server/package.json` — `preflight:ollama` script

## Spec
Nova Daemon (`memory/ollama_preflight_test_spec.md`)

## Test plan
- [x] All 43 preflight tests pass
- [x] Full suite: 1570/1571 pass (1 pre-existing CopilotBackend failure)
- [x] Build succeeds
- [ ] Integration test: `npm run preflight:ollama -- --url http://<4090-host>:11434` (pending Stefan providing LAN IP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)