### PR TITLE
feat: wire OllamaSessionLauncher into agent layer factory

### DIFF
--- a/server/src/loop/applicationTypes.ts
+++ b/server/src/loop/applicationTypes.ts
@@ -74,7 +74,9 @@ export interface ApplicationConfig {
   /** Maximum concurrent Claude API sessions (default: 2). Prevents rate-limit saturation when work pipeline and conversations overlap. */
   maxConcurrentSessions?: number;
   /** Which session launcher to use for agent reasoning sessions (default: "claude"). */
-  sessionLauncher?: "claude" | "gemini";
+  sessionLauncher?: "claude" | "gemini" | "ollama";
+  /** Base URL for the Ollama server when sessionLauncher is "ollama" (default: "http://localhost:11434"). */
+  ollamaBaseUrl?: string;
   /** Default code backend to use for code dispatch tasks (default: "claude"). */
   defaultCodeBackend?: "claude" | "copilot" | "gemini" | "auto";
   /** Configuration for the loop watchdog that detects stalls and injects reminders */

--- a/server/src/loop/createAgentLayer.ts
+++ b/server/src/loop/createAgentLayer.ts
@@ -4,6 +4,8 @@ import { PromptBuilder } from "../agents/prompts/PromptBuilder";
 import { AgentSdkLauncher, SdkQueryFn } from "../agents/claude/AgentSdkLauncher";
 import { GeminiSessionLauncher } from "../agents/gemini/GeminiSessionLauncher";
 import { CopilotSessionLauncher } from "../agents/copilot/CopilotSessionLauncher";
+import { OllamaSessionLauncher } from "../agents/ollama/OllamaSessionLauncher";
+import { FetchHttpClient } from "../agents/ollama/FetchHttpClient";
 import { ProcessTracker, ProcessTrackerConfig } from "../agents/claude/ProcessTracker";
 import { NodeProcessKiller } from "../agents/claude/NodeProcessKiller";
 import { NodeProcessRunner } from "../agents/claude/NodeProcessRunner";
@@ -93,6 +95,11 @@ export async function createAgentLayer(
     logger.debug("agent-layer: using CopilotSessionLauncher for cognitive roles");
     const copilotLauncher = new CopilotSessionLauncher(new NodeProcessRunner(), clock, config.model);
     gatedLauncher = new SemaphoreSessionLauncher(copilotLauncher, apiSemaphore);
+  } else if (config.sessionLauncher === "ollama") {
+    const ollamaBaseUrl = config.ollamaBaseUrl ?? "http://localhost:11434";
+    logger.debug(`agent-layer: using OllamaSessionLauncher for cognitive roles (${ollamaBaseUrl}, model: ${config.model})`);
+    const ollamaLauncher = new OllamaSessionLauncher(new FetchHttpClient(), clock, config.model, ollamaBaseUrl);
+    gatedLauncher = new SemaphoreSessionLauncher(ollamaLauncher, apiSemaphore);
   } else {
     gatedLauncher = new SemaphoreSessionLauncher(launcher, apiSemaphore);
   }


### PR DESCRIPTION
## Summary
- Add `"ollama"` to `sessionLauncher` config option in `ApplicationConfig`
- Add `ollamaBaseUrl` config field (default: `http://localhost:11434`)
- Wire `OllamaSessionLauncher` + `FetchHttpClient` into `createAgentLayer.ts` launcher switch

Enables self-hosted inference via Ollama for any agent. Activation: set `sessionLauncher: "ollama"` and `ollamaBaseUrl` in config.json.

Preflight verified against live endpoint (https://ollama.lbsa71.net): all 11 probes green, 51.2 tok/s, 13.9GB VRAM.

## Test plan
- [x] Build succeeds
- [x] 1570/1571 tests pass (1 pre-existing CopilotBackend failure)
- [ ] Integration: switch Nova's config, rebuild, restart, verify first self-hosted cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)