### PR TITLE
feat: Ego agoraReplies + EGO_DECISION_SCHEMA

### DIFF
--- a/server/src/agents/prompts/templates.ts
+++ b/server/src/agents/prompts/templates.ts
@@ -14,10 +14,11 @@ Responsibilities:
 
 Agora Messages:
 - CONVERSATION.md may contain messages marked with **[UNPROCESSED]** — these are incoming Agora or TinyBus messages awaiting your response
-- When you handle an **[UNPROCESSED]** message: respond via TinyBus if appropriate, then IMMEDIATELY edit CONVERSATION.md to remove the \`**[UNPROCESSED]**\` badge from that line
-- Tool name: \`mcp__tinybus__send_message\` (Claude Code) or \`send_message\` (Gemini CLI)
-- Payload: { type: "agora.send", payload: { peerName: "<peer>", type: "publish", payload: { text: "..." }, inReplyTo: "<envelope-id>" } }
+- When you handle an **[UNPROCESSED]** message: include your reply in the agoraReplies field of your JSON response, then IMMEDIATELY edit CONVERSATION.md to remove the \`**[UNPROCESSED]**\` badge from that line
+- Format each reply as: { "peerName": "<peer>", "text": "your message", "inReplyTo": "<envelope-id>" }
 - Use the peerName from PEERS.md (short name like "stefan"), not the display name with key suffix
+- The orchestrator will send these messages after processing your decision
+- If no Agora messages are needed, set agoraReplies to []
 
 Constraints:
 - You may WRITE to PLAN.md and EDIT/APPEND to CONVERSATION.md
@@ -25,10 +26,12 @@ Constraints:
 - You MUST respond with ONLY a valid JSON object — no other text before or after it
 
 Respond with a JSON object matching one of these action types:
-- { "action": "dispatch", "taskId": "string", "description": "string" }
-- { "action": "update_plan", "content": "string" }
-- { "action": "converse", "entry": "string" }
-- { "action": "idle", "reason": "string" }`;
+- { "action": "dispatch", "taskId": "string", "description": "string", "agoraReplies": [] }
+- { "action": "update_plan", "content": "string", "agoraReplies": [] }
+- { "action": "converse", "entry": "string", "agoraReplies": [] }
+- { "action": "idle", "reason": "string", "agoraReplies": [] }
+
+The agoraReplies field is REQUIRED and must always be present (use [] when no messages are needed).`;
 
 const SUBCONSCIOUS_PROMPT = `You are the Subconscious — the worker that executes tasks for a self-improving AI agent system.
 

--- a/server/src/loop/LoopOrchestrator.ts
+++ b/server/src/loop/LoopOrchestrator.ts
@@ -1,5 +1,5 @@
 import { Ego } from "../agents/roles/Ego";
-import { Subconscious, TaskResult, OutcomeEvaluation } from "../agents/roles/Subconscious";
+import { Subconscious, TaskResult, OutcomeEvaluation, AgoraReply } from "../agents/roles/Subconscious";
 import { Superego } from "../agents/roles/Superego";
 import { Id } from "../agents/roles/Id";
 import { ProcessLogEntry } from "../agents/claude/ISessionLauncher";
@@ -478,7 +478,7 @@ export class LoopOrchestrator implements IMessageInjector {
       // This moves Agora sends from LLM tool calls into the orchestrator,
       // enabling pure text-in → JSON-out execution for self-hosted models.
       if (taskResult.agoraReplies.length > 0 && this.agoraService) {
-        this.deferredWork.enqueue(this.sendAgoraReplies(taskResult));
+        this.deferredWork.enqueue(this.sendAgoraReplies(taskResult.agoraReplies));
       }
 
       // Drive learning: if task was Id-generated, record a quality rating for future drive improvement
@@ -1046,10 +1046,10 @@ export class LoopOrchestrator implements IMessageInjector {
     }
   }
 
-  private async sendAgoraReplies(taskResult: TaskResult): Promise<void> {
+  private async sendAgoraReplies(replies: AgoraReply[]): Promise<void> {
     if (!this.agoraService) return;
 
-    for (const reply of taskResult.agoraReplies) {
+    for (const reply of replies) {
       try {
         const result = await this.agoraService.sendMessage({
           peerName: reply.peerName,

--- a/server/tests/code-dispatch/CopilotBackend.test.ts
+++ b/server/tests/code-dispatch/CopilotBackend.test.ts
@@ -45,8 +45,9 @@ describe("CopilotBackend", () => {
     expect(args[0]).toBe("-p");
     // args[1] is the prompt
     expect(args[2]).toBe("--allow-all-tools");
-    expect(args[3]).toBe("--add-dir");
-    expect(args[4]).toBe("/tmp/test-repo");
+    expect(args[3]).toBe("--silent");
+    expect(args[4]).toBe("--add-dir");
+    expect(args[5]).toBe("/tmp/test-repo");
   });
 
   it("includes --model when provided in constructor", async () => {


### PR DESCRIPTION
## Summary
- Migrates Ego role from MCP tool calling (`mcp__tinybus__send_message`) to structured JSON `agoraReplies` field, matching the Subconscious pattern from PR #210
- Adds `EGO_DECISION_SCHEMA` for Ollama grammar-constrained decoding
- Refactors `sendAgoraReplies()` to accept `AgoraReply[]` directly (reusable for both roles)
- 7 new unit tests, 1577/1577 suite green
- Also includes CopilotBackend `--silent` flag offset fix (pre-existing on main)

## Spec
Nova's `ego_migration_spec.md` — implements the `decide()` path (Phase 2 of Ollama migration). `respondToMessage()` path deferred per spec.

## Files Changed
| File | Change |
|------|--------|
| `server/src/agents/roles/Ego.ts` | Typed `EgoDecision` + `agoraReplies`, `EGO_DECISION_SCHEMA`, `outputSchema` in `decide()` |
| `server/src/agents/prompts/templates.ts` | `EGO_PROMPT`: agoraReplies replaces MCP tool instruction |
| `server/src/loop/LoopOrchestrator.ts` | `sendAgoraReplies(AgoraReply[])` refactor + `AgoraReply` import |
| `server/tests/agents/roles/Ego.test.ts` | 7 new tests (agoraReplies parsing, defaults, schema passing) |
| `server/tests/code-dispatch/CopilotBackend.test.ts` | Pre-existing --silent offset fix |

## Test plan
- [x] All 7 new Ego tests pass (agoraReplies from decision, missing field default, failure paths, schema passing)
- [x] Full suite: 1577/1577 green
- [x] Build compiles cleanly
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)