### PR TITLE
feat: RFC-002 Phase 1 — targetPubkey routing for unknown peer replies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "substrate",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "substrate",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "workspaces": [
         "server",
         "client"
@@ -20,7 +20,7 @@
     },
     "client": {
       "name": "@substrate/client",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -10208,7 +10208,7 @@
     },
     "server": {
       "name": "@substrate/server",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.37",
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/server/src/agora/AgoraMessageHandler.ts
+++ b/server/src/agora/AgoraMessageHandler.ts
@@ -292,7 +292,7 @@ export class AgoraMessageHandler {
     let injected = false;
     const replyInstruction = knownPeer
       ? `Respond to this message if appropriate. Use the TinyBus MCP tool (${"`"}mcp__tinybus__send_message${"`"} in Claude Code, or ${"`"}send_message${"`"} in Gemini CLI) with type "agora.send" to reply. Example: { type: "agora.send", payload: { peerName: "${knownPeer}", type: "publish", payload: { text: "your response" }, inReplyTo: "${envelope.id}" } }`
-      : `Note: Sender (${senderDisplayName}) is not registered in PEERS.md. Replying via Agora is not possible unless the peer is added first.`;
+      : `Respond to this message if appropriate. Note: Sender (${senderDisplayName}) is not in PEERS.md, but you can reply via relay using targetPubkey. Use the TinyBus MCP tool (${"`"}mcp__tinybus__send_message${"`"} in Claude Code, or ${"`"}send_message${"`"} in Gemini CLI) with type "agora.send". Example: { type: "agora.send", payload: { targetPubkey: "${envelope.sender}", type: "publish", payload: { text: "your response" }, inReplyTo: "${envelope.id}" } }`;
     try {
       const agentPrompt = `[AGORA MESSAGE from ${senderDisplayName}]\nType: ${envelope.type}\nEnvelope ID: ${envelope.id}\nTimestamp: ${timestamp}\nPayload: ${payloadStr}\n\n${replyInstruction}`;
       injected = this.messageInjector.injectMessage(agentPrompt);

--- a/server/src/agora/IAgoraService.ts
+++ b/server/src/agora/IAgoraService.ts
@@ -6,6 +6,8 @@ import type { Envelope } from "@rookdaemon/agora" with { "resolution-mode": "imp
  */
 export interface IAgoraService {
   sendMessage(options: { peerName: string; type: string; payload: unknown; inReplyTo?: string }): Promise<{ ok: boolean; status: number; error?: string }>;
+  /** Reply to any pubkey via relay — no peer config needed (RFC-002 Phase 1) */
+  replyToEnvelope(options: { targetPubkey: string; type: string; payload: unknown; inReplyTo: string }): Promise<{ ok: boolean; status: number; error?: string }>;
   decodeInbound(message: string): Promise<{ ok: boolean; envelope?: Envelope; reason?: string }>;
   getPeers(): string[];
   getPeerConfig(name: string): { publicKey: string; url?: string; token?: string } | undefined;


### PR DESCRIPTION
## Summary

- Adds `replyToEnvelope()` to `IAgoraService` interface — relay-mediated reply to any pubkey, no peer config needed
- Routes `targetPubkey` field in `agora.send` payload to `replyToEnvelope()` (priority: targetPubkey > peerName > broadcast)
- Updates `AgoraMessageHandler` to give LLM actionable `targetPubkey` + `inReplyTo` reply instructions for unknown senders (was: "not possible")
- Updates all mock implementations in test files
- 6 new tests: 4 in AgoraOutboundProvider (routing, validation, errors, priority), 2 in AgoraMessageHandler (unknown sender instruction, known sender regression)

## Context

RFC-002 Peer Introduction Protocol, Phase 1. Companion to rookdaemon/agora#66 which adds the underlying `replyToEnvelope()` method to the Agora library.

The stranger-reply catch-22: unknown agents can message us via relay, but `agora.send` only supported `peerName` (requires pre-configuration). Now `targetPubkey` enables direct relay replies to any pubkey from an inbound envelope.

## Test plan

- [x] All 1637 tests pass (`npx jest`)
- [x] TypeScript build clean (`npm run build`)
- [x] 6 new tests covering targetPubkey routing, validation, error handling, and reply instruction generation
- [ ] Deploy all agents and verify end-to-end: unknown sender → relay message → agent sees targetPubkey instruction → agent replies successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)