### PR TITLE
fix: replace raw fs import with IFileSystem DI in LoopOrchestrator

### DIFF
--- a/server/src/loop/createLoopLayer.ts
+++ b/server/src/loop/createLoopLayer.ts
@@ -121,6 +121,7 @@ export async function createLoopLayer(
     substrate.findingTrackerSave,
     config.conversationSessionMaxDurationMs,
     config.substratePath,
+    fs,
   );
 
   // Wire up sleep/wake infrastructure

--- a/server/tests/loop/R2CeilingAndEndpointState.test.ts
+++ b/server/tests/loop/R2CeilingAndEndpointState.test.ts
@@ -1,6 +1,8 @@
 import * as realFs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { IFileSystem } from "../../src/substrate/abstractions/IFileSystem";
+import { NodeFileSystem } from "../../src/substrate/abstractions/NodeFileSystem";
 import { LoopOrchestrator } from "../../src/loop/LoopOrchestrator";
 import { InMemoryEventSink } from "../../src/loop/InMemoryEventSink";
 import { ImmediateTimer } from "../../src/loop/ImmediateTimer";
@@ -71,7 +73,7 @@ async function setupIdleSubstrate(fs: InMemoryFileSystem) {
   await fs.writeFile("/substrate/CONVERSATION.md", "# Conversation\n\n");
 }
 
-function createOrchestrator(substratePath?: string) {
+function createOrchestrator(substratePath?: string, fileSystem?: IFileSystem) {
   const deps = createDeps();
   const logger = new InMemoryLogger();
   const eventSink = new InMemoryEventSink();
@@ -82,6 +84,7 @@ function createOrchestrator(substratePath?: string) {
     config, logger,
     undefined, undefined, undefined, undefined, undefined,
     substratePath,
+    fileSystem,
   );
   return { orchestrator, logger, eventSink, deps };
 }
@@ -145,7 +148,8 @@ describe("readEndpointState() private helper", () => {
   });
 
   async function callReadEndpointState(substratePath: string): Promise<string> {
-    const { orchestrator } = createOrchestrator(substratePath);
+    const nodeFs = new NodeFileSystem();
+    const { orchestrator } = createOrchestrator(substratePath, nodeFs);
     return (orchestrator as unknown as { readEndpointState(): Promise<string> }).readEndpointState();
   }
 


### PR DESCRIPTION
## Summary
- Replaces `import * as fs from "fs"` in LoopOrchestrator with `IFileSystem` constructor injection
- `readEndpointState()` now uses `this.fileSystem.readFile()` instead of raw `fs.readFileSync()`
- Returns safe UNKNOWN fallback when no `fileSystem` is provided (graceful degradation)

Fixes #229

## Root cause
PR #221 introduced direct `fs` usage in LoopOrchestrator, bypassing the IFileSystem DI pattern used throughout the codebase. This caused SleepWake tests to interact with the real filesystem instead of InMemoryFileSystem.

## Files changed
- `src/loop/LoopOrchestrator.ts` — Replace fs import, add `fileSystem?: IFileSystem` constructor param
- `src/loop/createLoopLayer.ts` — Pass `fs` (IFileSystem) to constructor
- `tests/loop/R2CeilingAndEndpointState.test.ts` — Pass `NodeFileSystem` for endpoint state tests

## Test plan
- [x] R2CeilingAndEndpointState tests pass (9/9)
- [x] PromptBuilder tests pass
- [x] Ego tests pass
- [ ] SleepWake tests — pre-existing timeout on main, separate investigation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)