### PR TITLE
fix: move endpoint state injection to dispatch branch only

### DIFF
--- a/server/src/loop/LoopOrchestrator.ts
+++ b/server/src/loop/LoopOrchestrator.ts
@@ -434,10 +434,6 @@ export class LoopOrchestrator implements IMessageInjector {
       }
     }
 
-    // Endpoint state injection — read current state and inject into pending messages
-    const endpointStateContext = await this.readEndpointState();
-    this.pendingMessages.unshift(`[SYSTEM: CURRENT ENDPOINT STATE]\n${endpointStateContext}`);
-
     // R2 pre-dispatch ceiling check (deterministic, no LLM)
     if (this.metrics.successfulCycles >= 50) {
       this.logger.warn(`[R2] Session dispatch ceiling reached (${this.metrics.successfulCycles} cycles) — halting`);
@@ -488,6 +484,10 @@ export class LoopOrchestrator implements IMessageInjector {
       });
     } else {
       this.logger.debug(`cycle ${this.cycleNumber}: dispatching task "${dispatch.taskId}"`);
+
+      // Endpoint state injection — provide runtime context alongside task dispatch
+      const endpointStateContext = await this.readEndpointState();
+      this.pendingMessages.unshift(`[SYSTEM: CURRENT ENDPOINT STATE]\n${endpointStateContext}`);
 
       const pending = this.pendingMessages.length > 0 ? [...this.pendingMessages] : undefined;
       if (pending?.length) {


### PR DESCRIPTION
## Summary
- Endpoint state was injected into `pendingMessages` unconditionally on every cycle
- During idle cycles, this injected system message triggered pending message processing, which reset `consecutiveIdleCycles` to 0
- The loop could never reach the idle sleep threshold → SleepWake tests hung forever (6 timeouts)
- Move injection into the dispatch branch so it only runs when there's actual task work

## Test plan
- [x] SleepWake tests pass (21/21)
- [x] R2CeilingAndEndpointState tests pass (9/9)
- [x] Full suite passes (128 suites, 1650 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)