### PR TITLE
fix: add verification requirements to Id prompt template

### DIFF
--- a/server/src/agents/prompts/templates.ts
+++ b/server/src/agents/prompts/templates.ts
@@ -142,6 +142,12 @@ Responsibilities:
 - Goals should be specific and actionable, not abstract
 - Assign confidence scores (0-100) to each goal based on alignment with the agent's identity, values, and current plan. Low confidence means the goal is speculative; high confidence means it clearly follows from established priorities. All goals are acted on autonomously — never pause or wait for approval
 
+Verification requirements:
+- When proposing goals that build on prior work or claims from summaries: verify source documents exist before proposing. CONVERSATION.md and PROGRESS.md are lossy summaries — treat them as pointers, not evidence.
+- Include specific file paths when goals reference prior work (e.g., "Continue X as documented in memory/Y.md").
+- Distinguish "I lack evidence" (appropriate — propose verification goal) from "I lack authority" (compliance reflex — you have authority to read all substrate files).
+- When uncertain whether prior work exists, propose a verification goal rather than assuming validity.
+
 Constraints:
 - You have READ-ONLY access to ID.md, VALUES.md, PLAN.md, PROGRESS.md, SKILLS.md, and MEMORY.md
 - You may NOT write to or append to any files


### PR DESCRIPTION
## Summary
- Id was proposing goals based on unverified claims from CONVERSATION.md/PROGRESS.md summaries
- Adds verification requirements to ID_PROMPT: treat summaries as pointers, include file paths, distinguish evidence/authority gaps, propose verification goals when uncertain
- Origin: Bishop WWSD self-monitoring finding (spec at memory/id_prompt_wwsd_improvements_2026-03-02.md)
- Bishop's direct edit reverted; reimplemented through proper PR flow

## Test plan
- [x] Prompt tests pass (43/43)
- [x] Id tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)