### PR TITLE
fix: separate ollamaModel config from Claude/Gemini model field

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -78,6 +78,7 @@ const AppConfigSchema = z
     progressMaxBytes: z.number().int().min(1).optional(),
     sessionLauncher: z.enum(["claude", "gemini", "copilot", "ollama"]).optional(),
     ollamaBaseUrl: z.string().url().optional(),
+    ollamaModel: z.string().optional(),
     defaultCodeBackend: z.enum(["claude", "copilot", "gemini", "auto"]).optional(),
   })
   .refine(
@@ -182,6 +183,8 @@ export interface AppConfig {
   sessionLauncher?: "claude" | "gemini" | "copilot" | "ollama";
   /** Base URL for the Ollama server when sessionLauncher is "ollama" (default: "http://localhost:11434"). */
   ollamaBaseUrl?: string;
+  /** Model name for Ollama when sessionLauncher is "ollama" (default: "qwen3:14b"). Separate from `model` which is the Claude/Gemini model name. */
+  ollamaModel?: string;
   /** Default code backend to use for code dispatch tasks (default: "claude"). */
   defaultCodeBackend?: "claude" | "copilot" | "gemini" | "auto";
   /** Configuration for the loop watchdog that detects stalls and injects reminders */
@@ -356,6 +359,7 @@ export async function resolveConfig(
     progressMaxBytes: fileConfig.progressMaxBytes ?? defaults.progressMaxBytes,
     sessionLauncher: fileConfig.sessionLauncher ?? defaults.sessionLauncher,
     ollamaBaseUrl: fileConfig.ollamaBaseUrl,
+    ollamaModel: fileConfig.ollamaModel,
     defaultCodeBackend: fileConfig.defaultCodeBackend ?? defaults.defaultCodeBackend,
     watchdog: fileConfig.watchdog
       ? {

--- a/server/src/loop/applicationTypes.ts
+++ b/server/src/loop/applicationTypes.ts
@@ -77,6 +77,8 @@ export interface ApplicationConfig {
   sessionLauncher?: "claude" | "gemini" | "ollama";
   /** Base URL for the Ollama server when sessionLauncher is "ollama" (default: "http://localhost:11434"). */
   ollamaBaseUrl?: string;
+  /** Model name for Ollama when sessionLauncher is "ollama" (default: "qwen3:14b"). Separate from `model` which is the Claude/Gemini model name. */
+  ollamaModel?: string;
   /** Default code backend to use for code dispatch tasks (default: "claude"). */
   defaultCodeBackend?: "claude" | "copilot" | "gemini" | "auto";
   /** Configuration for the loop watchdog that detects stalls and injects reminders */

--- a/server/src/loop/createAgentLayer.ts
+++ b/server/src/loop/createAgentLayer.ts
@@ -97,8 +97,8 @@ export async function createAgentLayer(
     gatedLauncher = new SemaphoreSessionLauncher(copilotLauncher, apiSemaphore);
   } else if (config.sessionLauncher === "ollama") {
     const ollamaBaseUrl = config.ollamaBaseUrl ?? "http://localhost:11434";
-    logger.debug(`agent-layer: using OllamaSessionLauncher for cognitive roles (${ollamaBaseUrl}, model: ${config.model})`);
-    const ollamaLauncher = new OllamaSessionLauncher(new FetchHttpClient(), clock, config.model, ollamaBaseUrl);
+    logger.debug(`agent-layer: using OllamaSessionLauncher for cognitive roles (${ollamaBaseUrl}, model: ${config.ollamaModel ?? "default"})`);
+    const ollamaLauncher = new OllamaSessionLauncher(new FetchHttpClient(), clock, config.ollamaModel, ollamaBaseUrl);
     gatedLauncher = new SemaphoreSessionLauncher(ollamaLauncher, apiSemaphore);
   } else {
     gatedLauncher = new SemaphoreSessionLauncher(launcher, apiSemaphore);

--- a/server/src/startup.ts
+++ b/server/src/startup.ts
@@ -117,6 +117,7 @@ export async function startServer(config: AppConfig, options?: StartServerOption
     watchdog: config.watchdog,
     sessionLauncher: config.sessionLauncher,
     ollamaBaseUrl: config.ollamaBaseUrl,
+    ollamaModel: config.ollamaModel,
     defaultCodeBackend: config.defaultCodeBackend,
   });
   appForCleanup = app;


### PR DESCRIPTION
## Summary
- Adds `ollamaModel` as a separate config field for Ollama model selection
- `createAgentLayer` now passes `config.ollamaModel` (not `config.model`) to OllamaSessionLauncher
- When `ollamaModel` is undefined, OllamaSessionLauncher falls through to its DEFAULT_MODEL ("qwen3:14b")
- No breaking changes — existing configs without `ollamaModel` work unchanged

## Root Cause
When `sessionLauncher` was `"ollama"`, `config.model` (e.g., "sonnet") was passed directly to OllamaSessionLauncher, overriding its DEFAULT_MODEL. Ollama returned HTTP 404 for "sonnet", leaving Nova in a failure loop for ~8 hours (970+ cycles).

## Test plan
- [x] Build passes (tsup clean)
- [x] 128 suites, 1650 tests green (no regressions)
- [x] OllamaSessionLauncher existing tests validate model fallback chain
- [ ] Deploy and verify: set `ollamaModel: "qwen3:14b"` in Nova's config, switch to Ollama, confirm correct model in API request

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)