### PR TITLE
fix: treat stale .endpoint_state.json as UNKNOWN, accept checkedAt field

### DIFF
--- a/server/src/loop/LoopOrchestrator.ts
+++ b/server/src/loop/LoopOrchestrator.ts
@@ -1421,8 +1421,19 @@ export class LoopOrchestrator implements IMessageInjector {
     }
   }
 
-  private formatEndpointStateForInjection(state: { status?: string; lastChecked?: string; lastSeen?: string; consecutiveDown?: number; consecutiveDegraded?: number }): string {
-    const ts = state.lastChecked ?? this.clock.now().toISOString();
+  private formatEndpointStateForInjection(state: { status?: string; lastChecked?: string; checkedAt?: string; lastSeen?: string; consecutiveDown?: number; consecutiveDegraded?: number }): string {
+    // Accept both field name conventions: checkedAt (external monitoring) and lastChecked (internal)
+    const rawTs = state.checkedAt ?? state.lastChecked;
+    const ts = rawTs ?? this.clock.now().toISOString();
+    // Staleness check: treat state older than 2 hours as UNKNOWN to avoid stale-UP false positives
+    if (rawTs) {
+      const ageMs = this.clock.now().getTime() - new Date(rawTs).getTime();
+      const twoHoursMs = 2 * 60 * 60 * 1000;
+      if (ageMs > twoHoursMs) {
+        const hoursAgo = Math.round(ageMs / 3600000);
+        return `[ENDPOINT STATE: UNKNOWN — state file is stale (last updated ${ts}, ~${hoursAgo}h ago). Treat as DOWN; probe before dispatching inference-gated tasks.]`;
+      }
+    }
     if (!state.status || state.status === "unknown") {
       return "[ENDPOINT STATE: UNKNOWN — endpoint not yet probed this session. Status in MEMORY.md may be stale.]";
     }

--- a/server/tests/loop/R2CeilingAndEndpointState.test.ts
+++ b/server/tests/loop/R2CeilingAndEndpointState.test.ts
@@ -194,4 +194,24 @@ describe("readEndpointState() private helper", () => {
     const result = await callReadEndpointState(tempDir);
     expect(result).toContain("UNKNOWN");
   });
+
+  it("T6: stale state (>2h old) → returns UNKNOWN with staleness message regardless of status", async () => {
+    // Fixed clock is 2025-06-15T10:00:00Z; 3h before = 2025-06-15T07:00:00Z
+    const staleTs = "2025-06-15T07:00:00.000Z";
+    const state = { status: "up", checkedAt: staleTs, consecutiveDown: 0 };
+    realFs.writeFileSync(path.join(tempDir, ".endpoint_state.json"), JSON.stringify(state));
+    const result = await callReadEndpointState(tempDir);
+    expect(result).toContain("UNKNOWN");
+    expect(result).toContain("stale");
+  });
+
+  it("T7: checkedAt field (external monitoring format) within 2h → parses as UP correctly", async () => {
+    // Fixed clock is 2025-06-15T10:00:00Z; 30min before = 2025-06-15T09:30:00Z
+    const recentTs = "2025-06-15T09:30:00.000Z";
+    const state = { status: "up", checkedAt: recentTs, consecutiveDown: 0 };
+    realFs.writeFileSync(path.join(tempDir, ".endpoint_state.json"), JSON.stringify(state));
+    const result = await callReadEndpointState(tempDir);
+    expect(result).toContain("Status: UP");
+    expect(result).toContain("Ollama-gated tasks: GO");
+  });
 });


### PR DESCRIPTION
## Problem

Two bugs in `formatEndpointStateForInjection` causing persistent false-positive UP state injection:

1. **Field name mismatch**: External monitoring service writes `.endpoint_state.json` with `checkedAt` field, but the function expected `lastChecked`. Since `lastChecked` was undefined, the timestamp always fell back to `this.clock.now().toISOString()` — making the injected state appear freshly probed when it was actually stale.

2. **No staleness guard**: A state file written days or weeks ago was trusted indefinitely. When the monitoring service stopped running (e.g. during a colo rack investigation), the last-known-good UP state persisted, causing every Ego cycle to inject `Status: UP — Connectivity ok, inference ok` even when Ollama was actually DOWN.

**Observed impact**: `.endpoint_state.json` was last written `2026-03-01T22:34:56Z`. Ollama went DOWN on `2026-03-12`. For 10+ days the runtime injected false UP state, sending misleading "Ollama-gated tasks: GO" signals.

## Fix

- Accept both `checkedAt` (external monitoring) and `lastChecked` (internal) field names
- Add staleness check: state older than 2 hours is treated as UNKNOWN, which maps to DOWN per existing UNKNOWN=DOWN spec. Message includes how stale the file is.
- New tests: T6 (stale→UNKNOWN), T7 (checkedAt field→UP)

## Tests

2020/2020 pass. +2 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)